### PR TITLE
Add projects using Stargate section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Check out the [included app](./app/src/main/kotlin/com/zugaldia/stargate/app) fo
 | Trash                 | ❌         | ❌          | ❌       |
 | Usb                   | ❌         | ❌          | ❌       |
 | Wallpaper             | ❌         | ❌          | ❌       |
+
+# Projects Using Stargate
+
+- [Speed of Sound](https://github.com/zugaldia/speedofsound) — Voice typing for the Linux desktop.
+
+If your application, project, or CLI depends on Stargate, feel free to open a PR to add it to this list.


### PR DESCRIPTION
## Summary
- Adds a new "Projects Using Stargate" section to the README listing projects that depend on this library.
- Lists [Speed of Sound](https://github.com/zugaldia/speedofsound) as the first project.
- Includes an invitation for others to open PRs to add their projects.

## Test plan
- [ ] Verify the README renders correctly on GitHub.