### PR TITLE
Add versions plugin and update java-gi to 0.14.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     // The shared code is located in `buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts`.
     id("buildsrc.convention.kotlin-jvm")
     application
+    alias(libs.plugins.versions)
 }
 
 dependencies {

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     // The shared code is located in `buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts`.
     id("buildsrc.convention.kotlin-jvm")
     application
+    alias(libs.plugins.versions)
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@
 clikt = "5.1.0"
 dbusJava = "5.2.0"
 detekt = "2.0.0-alpha.2"
-javaGi = "0.14.0"
+javaGi = "0.14.1"
 kotlin = "2.3.10"
 kotlinxCoroutines = "1.10.2"
 kotlinxDatetime = "0.7.1"
@@ -14,6 +14,7 @@ kotlinxSerializationJSON = "1.10.0"
 log4j = "2.25.3"
 mavenPublish = "0.36.0"
 slf4j = "2.0.17"
+versionsPlugin = "0.53.0"
 
 [libraries]
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
@@ -38,3 +39,4 @@ kotlinxEcosystem = ["kotlinxDatetime", "kotlinxSerialization", "kotlinxCoroutine
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 kotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `java-library`
     alias(libs.plugins.kotlinPluginSerialization)
     alias(libs.plugins.mavenPublish)
+    alias(libs.plugins.versions)
 }
 
 sourceSets {


### PR DESCRIPTION
## Summary
- Add [ben-manes versions plugin](https://github.com/ben-manes/gradle-versions-plugin) (0.53.0) to app, generator, and sdk modules for dependency update checking via `./gradlew dependencyUpdates`
- Bump java-gi from 0.14.0 to 0.14.1 (the only stable update currently available)

## Test plan
- [x] `make build` passes
- [ ] Verify `./gradlew dependencyUpdates` runs successfully