### PR TITLE
Add missing GTK4 dependency to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install GTK4
+        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The release workflow was missing the `Install GTK4` step that the build workflow already has
- App tests call `Gdk.unicodeToKeyval()` / `Gdk.keyvalToUnicode()` via java-gi, which require `libgtk-4-dev` on the runner
- This caused all 5 `AppUtilsTest` tests to fail with `ExceptionInInitializerError` in the [v0.4.0 release run](https://github.com/zugaldia/stargate/actions/runs/24078818817)

## Test plan
- [ ] Verify the PR build passes
- [ ] After merge, delete the v0.4.0 release and tag, re-tag, and push to trigger a successful release