### PR TITLE
chore: add GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: zugaldia

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ If your application, project, or CLI depends on Stargate, feel free to open a PR
 
 To build the project from source and learn how to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+If you find Stargate useful, consider [sponsoring this work](https://github.com/sponsors/zugaldia).
+
 # Built With
 
 Stargate stands on the shoulders of these excellent open source projects:

--- a/data/com.zugaldia.Stargate.metainfo.xml.in
+++ b/data/com.zugaldia.Stargate.metainfo.xml.in
@@ -17,6 +17,7 @@
     <url type="homepage">https://github.com/zugaldia/stargate</url>
     <url type="vcs-browser">https://github.com/zugaldia/stargate</url>
     <url type="bugtracker">https://github.com/zugaldia/stargate/issues</url>
+    <url type="donation">https://github.com/sponsors/zugaldia</url>
 
     <url type="contact">https://www.zugaldia.com</url>
     <developer id="com.zugaldia">


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to display a Sponsor button on the repository page, linking to GitHub Sponsors.

## Test plan
- [ ] Verify the Sponsor button appears on the repository page after merging