### PR TITLE
Add Status Notifier Item support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export JDK_JAVA_OPTIONS = --enable-native-access=ALL-UNNAMED
 
 .PHONY: run build check clean shadow-build shadow-run \
 	flatpak-sources flatpak-linter flatpak-build flatpak-bundle flatpak-run \
-	publish-local generate-java
+	publish-local generate-java generate-status-notifier
 
 run: clean
 	./gradlew :app:run
@@ -52,3 +52,6 @@ publish-central:
 generate-java:
 	rm -rf sdk/src/main/generated
 	./gradlew :generator:run --args="generate-java"
+
+generate-status-notifier:
+	./gradlew :generator:run --args="generate-status-notifier"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ including Snaps. They can be used by any application, sandboxed or not, to provi
 features, such as taking screenshots, recording, and accessing files, that work consistently across desktop
 environments, like GNOME and KDE, and across display servers including X11 and Wayland.
 
-In addition to XDG Desktop Portals, Stargate also includes support for the related Freedesktop Status Notifier Item
-Specification, which enables system tray icon integration.
+In addition to XDG Desktop Portals, Stargate also includes support for the
+[Freedesktop Status Notifier Item Specification](#support-for-status-notifier-item-specification), which enables system tray icon integration.
 
 # Getting Started
 
@@ -96,7 +96,7 @@ and an optional menu.
 
 A word of caution: system tray icons are not well standardized on Linux today and APIs might change if and when desktop
 environments settle on a common framework. Under the hood, the Status Notifier Item Specification relies on a KDE
-extension for items (`org.kde.StatusNotifierItem`) and an Ubuntu extension for menus (`com.canonical.dbusmenu`).
+specification for items (`org.kde.StatusNotifierItem`) and an Ubuntu specification for menus (`com.canonical.dbusmenu`).
 Support across distributions and desktop environments varies, and some distributions require
 [a dedicated GNOME extension](https://github.com/ubuntu/gnome-shell-extension-appindicator) to be installed.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ A Kotlin library that provides JVM applications with access to
 [XDG Desktop Portals](https://flatpak.github.io/xdg-desktop-portal/docs) on Linux.
 
 XDG Desktop Portals originated from the Flatpak project but have since become a widely adopted Linux desktop standard,
-including Snaps. They are even used outside of sandboxes to provide a standardized API to common desktop features,
-such as taking screenshots, recording, and accessing files, that work consistently across desktop environments, like
-GNOME and KDE, and across display servers including X11 and Wayland.
+including Snaps. They can be used by any application, sandboxed or not, to provide a standardized API to common desktop
+features, such as taking screenshots, recording, and accessing files, that work consistently across desktop
+environments, like GNOME and KDE, and across display servers including X11 and Wayland.
+
+In addition to XDG Desktop Portals, Stargate also includes support for the related Freedesktop Status Notifier Item
+Specification, which enables system tray icon integration.
 
 # Getting Started
 
@@ -83,6 +86,24 @@ This library provides access to the Registry portal through `DesktopPortal.regis
 utility function to detect if the application is running inside a sandbox. See the
 [demo application](./app/src/main/kotlin/com/zugaldia/stargate/app/App.kt) for a working example.
 This demo application can run both as an unsandboxed app (`make run`) and as a sandboxed Flatpak (`make flatpak-run`).
+
+# Support for Status Notifier Item Specification
+
+While technically not part of the XDG Desktop Portals specification, this library also supports the related
+[Freedesktop Status Notifier Item Specification](https://specifications.freedesktop.org/status-notifier-item/0.1/index.html).
+This is essentially the D-Bus interface that allows applications to provide a system tray icon to report their status,
+and an optional menu.
+
+A word of caution: system tray icons are not well standardized on Linux today and APIs might change if and when desktop
+environments settle on a common framework. Under the hood, the Status Notifier Item Specification relies on a KDE
+extension for items (`org.kde.StatusNotifierItem`) and an Ubuntu extension for menus (`com.canonical.dbusmenu`).
+Support across distributions and desktop environments varies, and some distributions require
+[a dedicated GNOME extension](https://github.com/ubuntu/gnome-shell-extension-appindicator) to be installed.
+
+This mechanism described above is, in turn, different from the indicator icons provided by GNOME Shell Extensions.
+
+This library abstracts away this fragmentation for the application developer, and the bundled demo application provides
+a reference example on the "Status Notifier" screen.
 
 # Projects Using Stargate
 

--- a/app/src/main/kotlin/com/zugaldia/stargate/app/App.kt
+++ b/app/src/main/kotlin/com/zugaldia/stargate/app/App.kt
@@ -10,6 +10,8 @@ import com.zugaldia.stargate.app.remotedesktop.RemoteDesktopScreen
 import com.zugaldia.stargate.app.remotedesktop.RemoteDesktopViewModel
 import com.zugaldia.stargate.app.settings.SettingsScreen
 import com.zugaldia.stargate.app.settings.SettingsViewModel
+import com.zugaldia.stargate.app.status.StatusNotifierScreen
+import com.zugaldia.stargate.app.status.StatusNotifierViewModel
 import com.zugaldia.stargate.sdk.DesktopPortal
 import com.zugaldia.stargate.sdk.isSandboxed
 import kotlinx.coroutines.runBlocking
@@ -50,6 +52,7 @@ fun main(args: Array<String>) {
     val openUriViewModel = OpenUriViewModel(portal)
     val remoteDesktopViewModel = RemoteDesktopViewModel(portal)
     val settingsViewModel = SettingsViewModel(portal)
+    val statusNotifierViewModel = StatusNotifierViewModel()
 
     val app = Application(APPLICATION_ID, ApplicationFlags.DEFAULT_FLAGS)
 
@@ -57,7 +60,7 @@ fun main(args: Array<String>) {
         logger.info("Application activated")
         activate(
             app, globalShortcutsViewModel, notificationViewModel, openUriViewModel,
-            remoteDesktopViewModel, settingsViewModel
+            remoteDesktopViewModel, settingsViewModel, statusNotifierViewModel
         )
     }
 
@@ -68,6 +71,7 @@ fun main(args: Array<String>) {
             openUriViewModel.closeAndJoin()
             remoteDesktopViewModel.closeAndJoin()
             settingsViewModel.closeAndJoin()
+            statusNotifierViewModel.close()
         }
         portal.close()
     }
@@ -82,11 +86,13 @@ private fun activate(
     notificationViewModel: NotificationViewModel,
     openUriViewModel: OpenUriViewModel,
     remoteDesktopViewModel: RemoteDesktopViewModel,
-    settingsViewModel: SettingsViewModel
+    settingsViewModel: SettingsViewModel,
+    statusNotifierViewModel: StatusNotifierViewModel
 ) {
     val window = ApplicationWindow(app)
     window.title = APPLICATION_NAME
     window.setDefaultSize(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT)
+    statusNotifierViewModel.setWindow(window)
 
     val stack = Stack()
 
@@ -104,6 +110,9 @@ private fun activate(
 
     val settingsScreen = SettingsScreen(settingsViewModel)
     stack.addTitled(settingsScreen.build(), "settings", "Settings")
+
+    val statusNotifierScreen = StatusNotifierScreen(statusNotifierViewModel)
+    stack.addTitled(statusNotifierScreen.build(), "status-notifier", "Status Notifier")
 
     val sidebar = StackSidebar()
     sidebar.stack = stack

--- a/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierItemStargate.kt
+++ b/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierItemStargate.kt
@@ -1,0 +1,16 @@
+package com.zugaldia.stargate.app.status
+
+import com.zugaldia.stargate.sdk.status.StargateMenu
+import com.zugaldia.stargate.sdk.status.StargateStatusNotifierItem
+import org.kde.PropertyToolTipStruct
+
+class StatusNotifierItemStargate(
+    menu: StargateMenu?,
+    onActivate: (token: String?) -> Unit,
+    onSecondaryActivate: (token: String?) -> Unit,
+) : StargateStatusNotifierItem(menu, onActivate, onSecondaryActivate) {
+    override fun getId(): String = "stargate"
+    override fun getTitle(): String = "Stargate"
+    override fun getIconName(): String = "dialog-information"
+    override fun getToolTipInfo(): Pair<String, String> = Pair("Stargate", "XDG Desktop Portal Integration")
+}

--- a/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierScreen.kt
+++ b/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierScreen.kt
@@ -1,0 +1,76 @@
+package com.zugaldia.stargate.app.status
+
+import com.zugaldia.stargate.app.LABEL_MAX_WIDTH_CHARS
+import com.zugaldia.stargate.app.SIGNAL_STATE_CHANGED
+import com.zugaldia.stargate.app.SPACING
+import org.gnome.gtk.Align
+import org.gnome.gtk.Box
+import org.gnome.gtk.Button
+import org.gnome.gtk.Label
+import org.gnome.gtk.Orientation
+import org.gnome.gtk.Widget
+
+class StatusNotifierScreen(private val viewModel: StatusNotifierViewModel) {
+    private lateinit var connectButton: Button
+    private lateinit var statusLabel: Label
+    private lateinit var hostRegisteredLabel: Label
+    private lateinit var protocolVersionLabel: Label
+    private lateinit var registeredItemsLabel: Label
+
+    fun build(): Widget {
+        val box = Box(Orientation.VERTICAL, SPACING)
+        box.hexpand = true
+        box.vexpand = true
+        box.halign = Align.CENTER
+        box.valign = Align.CENTER
+
+        connectButton = Button.withLabel("Connect to Status Notifier Watcher")
+        connectButton.onClicked {
+            viewModel.connect()
+        }
+
+        statusLabel = Label("")
+        statusLabel.maxWidthChars = LABEL_MAX_WIDTH_CHARS
+        statusLabel.wrap = true
+
+        hostRegisteredLabel = Label("")
+        protocolVersionLabel = Label("")
+        registeredItemsLabel = Label("")
+        registeredItemsLabel.maxWidthChars = LABEL_MAX_WIDTH_CHARS
+        registeredItemsLabel.wrap = true
+
+        box.append(connectButton)
+        box.append(statusLabel)
+        box.append(hostRegisteredLabel)
+        box.append(protocolVersionLabel)
+        box.append(registeredItemsLabel)
+
+        viewModel.connect(SIGNAL_STATE_CHANGED, object : StatusNotifierViewModel.StateChanged {
+            override fun apply() {
+                updateUI(viewModel.state)
+            }
+        })
+
+        return box
+    }
+
+    private fun updateUI(state: StatusNotifierState) {
+        connectButton.sensitive = !state.isLoading
+        connectButton.label = if (state.isLoading) "Connecting..." else "Connect to Status Notifier Watcher"
+        statusLabel.label = state.error ?: state.message ?: ""
+
+        val connected = state.isConnected
+        hostRegisteredLabel.visible = connected
+        protocolVersionLabel.visible = connected
+        registeredItemsLabel.visible = connected
+
+        if (connected) {
+            hostRegisteredLabel.label = "Host Registered: ${state.isStatusNotifierHostRegistered}"
+            protocolVersionLabel.label = "Protocol Version: ${state.protocolVersion}"
+            registeredItemsLabel.label = "Registered Items: ${
+                if (state.registeredStatusNotifierItems.isEmpty()) "none"
+                else state.registeredStatusNotifierItems.joinToString(", ")
+            }"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierState.kt
+++ b/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierState.kt
@@ -1,0 +1,12 @@
+package com.zugaldia.stargate.app.status
+
+data class StatusNotifierState(
+    val isLoading: Boolean = false,
+    val isConnected: Boolean = false,
+    val registeredServiceName: String? = null,
+    val isStatusNotifierHostRegistered: Boolean? = null,
+    val protocolVersion: Int? = null,
+    val registeredStatusNotifierItems: List<String> = emptyList(),
+    val message: String? = null,
+    val error: String? = null
+)

--- a/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/stargate/app/status/StatusNotifierViewModel.kt
@@ -1,0 +1,140 @@
+package com.zugaldia.stargate.app.status
+
+import com.zugaldia.stargate.app.SIGNAL_STATE_CHANGED
+import com.zugaldia.stargate.sdk.status.StargateMenu
+import com.zugaldia.stargate.sdk.status.StargateMenuItem
+import com.zugaldia.stargate.sdk.status.StatusNotifierManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.gnome.glib.GLib
+import org.gnome.gobject.GObject
+import org.gnome.gtk.ApplicationWindow
+import org.javagi.gobject.annotations.Signal
+import org.slf4j.LoggerFactory
+
+class StatusNotifierViewModel : GObject(), AutoCloseable {
+    private val logger = LoggerFactory.getLogger(StatusNotifierViewModel::class.java)
+
+    private val job: Job = SupervisorJob()
+    private val scope = CoroutineScope(job + Dispatchers.IO)
+
+    private var manager: StatusNotifierManager? = null
+    private var window: ApplicationWindow? = null
+
+    fun setWindow(window: ApplicationWindow) {
+        this.window = window
+    }
+
+    private var _state: StatusNotifierState = StatusNotifierState()
+    val state: StatusNotifierState
+        get() = _state
+
+    @Signal
+    interface StateChanged {
+        fun apply()
+    }
+
+    private fun updateState(value: StatusNotifierState) {
+        _state = value
+        GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+            logger.info("State updated, emitting $SIGNAL_STATE_CHANGED signal")
+            emit(SIGNAL_STATE_CHANGED)
+            false
+        }
+    }
+
+    private fun onMenuClick(label: String, action: () -> Unit = {}): (tokenSupplier: () -> String?) -> Unit =
+        { tokenSupplier ->
+            GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                val token = tokenSupplier()
+                logger.info("Menu: $label (token=$token)")
+                token?.let { window?.setStartupId(it) }
+                action()
+                false
+            }
+        }
+
+    private fun buildMenu(): StargateMenu = StargateMenu(
+        items = listOf(
+            StargateMenuItem.Action(id = 1, label = "Open", onClick = onMenuClick("Open") { window?.present() }),
+            StargateMenuItem.Separator(id = 2),
+            StargateMenuItem.Action(id = 3, label = "Item A", onClick = onMenuClick("Clicked A")),
+            StargateMenuItem.Action(id = 4, label = "Item B", onClick = onMenuClick("Clicked B")),
+            StargateMenuItem.Action(id = 5, label = "Item C", onClick = onMenuClick("Clicked C")),
+            StargateMenuItem.Separator(id = 6),
+            StargateMenuItem.Action(
+                id = 7, label = "Quit",
+                onClick = onMenuClick("Quit") { window?.application?.quit() },
+            ),
+        ),
+        onMenuOpened = { logger.info("Menu: opened") },
+        onMenuClosed = { logger.info("Menu: closed") },
+    )
+
+    @Suppress("TooGenericExceptionCaught")
+    fun connect() {
+        updateState(_state.copy(isLoading = true, error = null))
+        scope.launch {
+            try {
+                manager?.close()
+                val connected = StatusNotifierManager.connect()
+                manager = connected
+                logger.info("Connected to StatusNotifierWatcher")
+
+                val item = StatusNotifierItemStargate(
+                    menu = buildMenu(),
+                    onActivate = { token ->
+                        GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                            logger.info("Presenting window on activate (token=$token)")
+                            token?.let { window?.setStartupId(it) }
+                            window?.present()
+                            false
+                        }
+                    },
+                    onSecondaryActivate = { token ->
+                        GLib.idleAdd(GLib.PRIORITY_DEFAULT) {
+                            logger.info("Presenting window on secondary activate (token=$token)")
+                            token?.let { window?.setStartupId(it) }
+                            window?.present()
+                            false
+                        }
+                    },
+                )
+                val serviceName = connected.registerItem(item, "com.zugaldia.Stargate")
+                logger.info("Registered StatusNotifierItem as $serviceName")
+
+                val hostRegistered = connected.isStatusNotifierHostRegistered()
+                val protocolVersion = connected.getProtocolVersion()
+                val registeredItems = connected.getRegisteredStatusNotifierItems()
+                logger.info(
+                    "Watcher: hostRegistered=$hostRegistered, " +
+                            "protocolVersion=$protocolVersion, items=$registeredItems"
+                )
+
+                updateState(
+                    _state.copy(
+                        isLoading = false,
+                        isConnected = true,
+                        registeredServiceName = serviceName,
+                        isStatusNotifierHostRegistered = hostRegistered,
+                        protocolVersion = protocolVersion,
+                        registeredStatusNotifierItems = registeredItems,
+                        message = "Registered icon as $serviceName"
+                    )
+                )
+            } catch (e: Exception) {
+                logger.error("Failed to connect to StatusNotifierWatcher", e)
+                updateState(_state.copy(isLoading = false, isConnected = false, error = e.message))
+            }
+        }
+    }
+
+    override fun close() {
+        job.cancel()
+        manager?.close()
+        manager = null
+    }
+}

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="debug">
+        <Root level="info">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/generator/src/main/kotlin/com/zugaldia/stargate/generator/Generator.kt
+++ b/generator/src/main/kotlin/com/zugaldia/stargate/generator/Generator.kt
@@ -14,6 +14,11 @@ const val SDK_GENERATED_DIR = "../sdk/src/main/generated"
 
 val EXCLUDED_PORTALS = listOf<String>()
 
+val STATUS_NOTIFIER_RESOURCES = listOf(
+    Triple("org.kde.StatusNotifierWatcher.xml", "org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher"),
+    Triple("org.kde.StatusNotifierItem.xml", "org.kde.StatusNotifierItem", "/StatusNotifierItem"),
+)
+
 class Generator : CliktCommand() {
     override fun help(context: Context) = "Stargate code generator CLI"
     override fun run() {
@@ -23,6 +28,21 @@ class Generator : CliktCommand() {
         }
     }
 }
+
+// New in dbus-java V6: when true, generates Struct-based return values instead of Tuples.
+// We keep this false so the generated code uses Tuples, which are compatible with dbus-java V5.
+// See: https://github.com/hypfvieh/dbus-java/blob/master/UPGRADE_TO_6x.md
+fun buildGenerator(introspectionData: String, busName: String, objectPath: String): InterfaceCodeGenerator =
+    InterfaceCodeGenerator(
+        /* disableFilter   */ true,
+        introspectionData,
+        objectPath,
+        busName,
+        /* packageName     */ null,
+        /* propertyMethods */ true,
+        /* argumentPrefix  */ null,
+        /* avoidUsingTuple */ false,
+    )
 
 class GenerateJava : CliktCommand(name = "generate-java") {
     override fun help(context: Context) = "Generate Java source files (in the sdk module)"
@@ -41,30 +61,11 @@ class GenerateJava : CliktCommand(name = "generate-java") {
     }
 
     private fun introspect(inputFile: File) {
-        val disableFilter = true
-        val introspectionData: String = inputFile.readText()
-        val objectPath: String = OBJECT_PATH
-        val busName: String = BUS_NAME
-        val packageName: String? = null
-        val propertyMethods = true
-        val argumentPrefix: String? = null
-        // New in dbus-java V6: when true, generates Struct-based return values instead of Tuples.
-        // We keep this false so the generated code uses Tuples, which are compatible with dbus-java V5.
-        // See: https://github.com/hypfvieh/dbus-java/blob/master/UPGRADE_TO_6x.md
-        val avoidUsingTuple = false
-        val generator = InterfaceCodeGenerator(
-            disableFilter,
-            introspectionData,
-            objectPath,
-            busName,
-            packageName,
-            propertyMethods,
-            argumentPrefix,
-            avoidUsingTuple
-        )
-
-        val ignoreDtd = true
-        val result: Map<File, String> = generator.analyze(ignoreDtd)
+        val result: Map<File, String> = buildGenerator(
+            introspectionData = inputFile.readText(),
+            busName = BUS_NAME,
+            objectPath = OBJECT_PATH,
+        ).analyze(true)
         val outputBaseDir = File(SDK_GENERATED_DIR)
         result.forEach { (file, content) ->
             if (file.path in EXCLUDED_PORTALS) {
@@ -79,6 +80,29 @@ class GenerateJava : CliktCommand(name = "generate-java") {
     }
 }
 
+class GenerateStatusNotifier : CliktCommand(name = "generate-status-notifier") {
+    override fun help(context: Context) = "Generate Java source files for StatusNotifier interfaces (in the sdk module)"
+    override fun run() {
+        STATUS_NOTIFIER_RESOURCES.forEach { (resourceName, busName, objectPath) ->
+            echo("Processing: $resourceName")
+            val introspectionData = javaClass.classLoader.getResource(resourceName)?.readText()
+                ?: error("Resource not found: $resourceName")
+            introspect(introspectionData, busName, objectPath)
+        }
+    }
+
+    private fun introspect(introspectionData: String, busName: String, objectPath: String) {
+        val result: Map<File, String> = buildGenerator(introspectionData, busName, objectPath).analyze(true)
+        val outputBaseDir = File(SDK_GENERATED_DIR)
+        result.forEach { (file, content) ->
+            val outputFile = File(outputBaseDir, file.path)
+            outputFile.parentFile.mkdirs()
+            outputFile.writeText(content)
+            echo("Generated: ${outputFile.path}")
+        }
+    }
+}
+
 fun main(args: Array<String>) = Generator()
-    .subcommands(GenerateJava())
+    .subcommands(GenerateJava(), GenerateStatusNotifier())
     .main(args)

--- a/generator/src/main/kotlin/com/zugaldia/stargate/generator/Generator.kt
+++ b/generator/src/main/kotlin/com/zugaldia/stargate/generator/Generator.kt
@@ -17,6 +17,7 @@ val EXCLUDED_PORTALS = listOf<String>()
 val STATUS_NOTIFIER_RESOURCES = listOf(
     Triple("org.kde.StatusNotifierWatcher.xml", "org.kde.StatusNotifierWatcher", "/StatusNotifierWatcher"),
     Triple("org.kde.StatusNotifierItem.xml", "org.kde.StatusNotifierItem", "/StatusNotifierItem"),
+    Triple("com.canonical.dbusmenu.xml", "com.canonical.dbusmenu", "/"),
 )
 
 class Generator : CliktCommand() {

--- a/generator/src/main/resources/.gitignore
+++ b/generator/src/main/resources/.gitignore
@@ -1,0 +1,3 @@
+StatusNotifierItem.xml
+StatusNotifierWatcher.xml
+DBusMenu.xml

--- a/generator/src/main/resources/Makefile
+++ b/generator/src/main/resources/Makefile
@@ -1,0 +1,8 @@
+download-kde:
+	wget https://github.com/KDE/kstatusnotifieritem/raw/refs/heads/master/src/org.kde.StatusNotifierItem.xml
+	wget https://github.com/KDE/kstatusnotifieritem/raw/refs/heads/master/src/org.kde.StatusNotifierWatcher.xml
+
+download-ubuntu:
+	wget https://github.com/ubuntu/gnome-shell-extension-appindicator/raw/refs/heads/master/interfaces-xml/StatusNotifierItem.xml
+	wget https://github.com/ubuntu/gnome-shell-extension-appindicator/raw/refs/heads/master/interfaces-xml/StatusNotifierWatcher.xml
+	wget https://github.com/ubuntu/gnome-shell-extension-appindicator/raw/refs/heads/master/interfaces-xml/DBusMenu.xml

--- a/generator/src/main/resources/Makefile
+++ b/generator/src/main/resources/Makefile
@@ -1,8 +1,13 @@
-download-kde:
+clean:
+	rm -f *xml
+
+download-kde: clean
 	wget https://github.com/KDE/kstatusnotifieritem/raw/refs/heads/master/src/org.kde.StatusNotifierItem.xml
 	wget https://github.com/KDE/kstatusnotifieritem/raw/refs/heads/master/src/org.kde.StatusNotifierWatcher.xml
+	wget https://github.com/KDE/kstatusnotifieritem/raw/refs/heads/master/src/libdbusmenu-qt/com.canonical.dbusmenu.xml
 
-download-ubuntu:
+# Currently unused
+download-ubuntu: clean
 	wget https://github.com/ubuntu/gnome-shell-extension-appindicator/raw/refs/heads/master/interfaces-xml/StatusNotifierItem.xml
 	wget https://github.com/ubuntu/gnome-shell-extension-appindicator/raw/refs/heads/master/interfaces-xml/StatusNotifierWatcher.xml
 	wget https://github.com/ubuntu/gnome-shell-extension-appindicator/raw/refs/heads/master/interfaces-xml/DBusMenu.xml

--- a/generator/src/main/resources/com.canonical.dbusmenu.xml
+++ b/generator/src/main/resources/com.canonical.dbusmenu.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+A library to allow applications to provide simple indications of
+information to be displayed to users of the application through the
+interface shell.
+
+SPDX-FileCopyrightText: 2009 Canonical Ltd.
+
+Authors:
+    Ted Gould <ted@canonical.com>
+    Aurélien Gâteau <aurelien.gateau@canonical.com>
+
+This program is free software: you can redistribute it and/or modify it 
+under the terms of either or both of the following licenses:
+
+1) the GNU Lesser General Public License version 3, as published by the 
+Free Software Foundation; and/or
+2) the GNU Lesser General Public License version 2.1, as published by 
+the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but 
+WITHOUT ANY WARRANTY; without even the implied warranties of 
+MERCHANTABILITY, SATISFACTORY QUALITY or FITNESS FOR A PARTICULAR 
+PURPOSE.  See the applicable version of the GNU Lesser General Public 
+License for more details.
+
+You should have received a copy of both the GNU Lesser General Public 
+License version 3 and version 2.1 along with this program.  If not, see 
+<http://www.gnu.org/licenses/>
+-->
+<node name="/" xmlns:dox="http://www.canonical.com/dbus/dox.dtd">
+    <dox:d><![CDATA[
+    @mainpage
+
+    The goal of DBusMenu is to expose menus on DBus.
+    
+    Main interface is documented here: @ref com::canonical::dbusmenu
+    ]]></dox:d>
+	<interface name="com.canonical.dbusmenu">
+		<dox:d><![CDATA[
+		A DBus interface to expose menus on DBus.
+
+		Menu items are represented with a unique numeric id and a dictionary of
+		properties.
+
+		To reduce the amount of DBus traffic, a property should only be returned
+		if its value is not the default value.
+
+		Available properties are:
+
+		<table>
+		<tr>
+			<th>Name</th>
+			<th>Type</th>
+			<th>Description</th>
+			<th>Default Value</th>
+		</tr>
+		<tr>
+			<td>type</td>
+			<td>String</td>
+			<td>Can be one of:
+			- "standard": an item which can be clicked to trigger an action or
+			  show another menu
+			- "separator": a separator
+
+			Vendor specific types can be added by prefixing them with
+			"x-<vendor>-".
+			</td>
+			<td>"standard"</td>
+		</tr>
+		<tr>
+			<td>label</td>
+			<td>string</td>
+			<td>Text of the item, except that:
+			-# two consecutive underscore characters "__" are displayed as a
+			single underscore,
+			-# any remaining underscore characters are not displayed at all,
+			-# the first of those remaining underscore characters (unless it is
+			the last character in the string) indicates that the following
+			character is the access key.
+			</td>
+			<td>""</td>
+		</tr>
+		<tr>
+			<td>enabled</td>
+			<td>boolean</td>
+			<td>Whether the item can be activated or not.</td>
+			<td>true</td>
+		</tr>
+		<tr>
+			<td>visible</td>
+			<td>boolean</td>
+			<td>True if the item is visible in the menu.</td>
+			<td>true</td>
+		</tr>
+		<tr>
+			<td>icon-name</td>
+			<td>string</td>
+			<td>Icon name of the item, following the freedesktop.org icon spec.</td>
+			<td>""</td>
+		</tr>
+		<tr>
+			<td>icon-data</td>
+			<td>binary</td>
+			<td>PNG data of the icon.</td>
+			<td>Empty</td>
+		</tr>
+		<tr>
+			<td>shortcut</td>
+			<td>array of arrays of strings</td>
+			<td>The shortcut of the item. Each array represents the key press
+			in the list of keypresses. Each list of strings contains a list of
+			modifiers and then the key that is used. The modifier strings
+			allowed are: "Control", "Alt", "Shift" and "Super".
+
+			- A simple shortcut like Ctrl+S is represented as:
+			  [["Control", "S"]]
+			- A complex shortcut like Ctrl+Q, Alt+X is represented as:
+			  [["Control", "Q"], ["Alt", "X"]]</td>
+			<td>Empty</td>
+		</tr>
+		<tr>
+			<td>toggle-type</td>
+			<td>string</td>
+			<td>
+			If the item can be toggled, this property should be set to:
+			- "checkmark": Item is an independent togglable item
+			- "radio": Item is part of a group where only one item can be
+			  toggled at a time
+			- "": Item cannot be toggled
+			</td>
+			<td>""</td>
+		</tr>
+		<tr>
+			<td>toggle-state</td>
+			<td>int</td>
+			<td>
+			Describe the current state of a "togglable" item. Can be one of:
+			- 0 = off
+			- 1 = on
+			- anything else = indeterminate
+
+			Note:
+			The implementation does not itself handle ensuring that only one
+			item in a radio group is set to "on", or that a group does not have
+			"on" and "indeterminate" items simultaneously; maintaining this
+			policy is up to the toolkit wrappers.
+			</td>
+			<td>-1</td>
+		</tr>
+		<tr>
+			<td>children-display</td>
+			<td>string</td>
+			<td>
+			If the menu item has children this property should be set to
+			"submenu".
+			</td>
+			<td>""</td>
+		</tr>
+		</table>
+
+		Vendor specific properties can be added by prefixing them with
+		"x-<vendor>-".
+		]]></dox:d>
+
+<!-- Properties -->
+		<property name="Version" type="u" access="read">
+			<dox:d>
+			Provides the version of the DBusmenu API that this API is
+			implementing.
+			</dox:d>
+		</property>
+
+        <property name="Status" type="s" access="read">
+            <dox:d>
+            Tells if the menus are in a normal state or they believe that they
+            could use some attention.  Cases for showing them would be if help
+            were referring to them or they accessors were being highlighted.
+            This property can have two values: "normal" in almost all cases and
+            "notice" when they should have a higher priority to be shown.
+            </dox:d>
+        </property>
+
+<!-- Functions -->
+
+		<method name="GetLayout">
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="DBusMenuLayoutItem"/>
+			<dox:d>
+			  Provides the layout and propertiers that are attached to the entries
+			  that are in the layout.  It only gives the items that are children
+			  of the item that is specified in @a parentId.  It will return all of the
+			  properties or specific ones depending of the value in @a propertyNames.
+
+			  The format is recursive, where the second 'v' is in the same format
+			  as the original 'a(ia{sv}av)'.  Its content depends on the value
+			  of @a recursionDepth.
+			</dox:d>
+			<arg type="i" name="parentId" direction="in">
+				<dox:d>The ID of the parent node for the layout.  For
+				grabbing the layout from the root node use zero.</dox:d>
+			</arg>
+			<arg type="i" name="recursionDepth" direction="in">
+				<dox:d>
+				  The amount of levels of recursion to use.  This affects the
+				  content of the second variant array.
+				  - -1: deliver all the items under the @a parentId.
+				  - 0: no recursion, the array will be empty.
+				  - n: array will contains items up to 'n' level depth.
+				</dox:d>
+			</arg>
+			<arg type="as" name="propertyNames" direction="in" >
+				<dox:d>
+					The list of item properties we are
+					interested in.  If there are no entries in the list all of
+					the properties will be sent.
+				</dox:d>
+			</arg>
+			<arg type="u" name="revision" direction="out">
+				<dox:d>The revision number of the layout.  For matching
+				with layoutUpdated signals.</dox:d>
+			</arg>
+			<arg type="(ia{sv}av)" name="layout" direction="out">
+				<dox:d>The layout, as a recursive structure.</dox:d>
+			</arg>
+		</method>
+
+		<method name="GetGroupProperties">
+			<annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QList&lt;int&gt;"/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusMenuItemList"/>
+			<dox:d>
+			Returns the list of items which are children of @a parentId.
+			</dox:d>
+			<arg type="ai" name="ids" direction="in" >
+				<dox:d>
+					A list of ids that we should be finding the properties
+					on.  If the list is empty, all menu items should be sent.
+				</dox:d>
+			</arg>
+			<arg type="as" name="propertyNames" direction="in" >
+				<dox:d>
+					The list of item properties we are
+					interested in.  If there are no entries in the list all of
+					the properties will be sent.
+				</dox:d>
+			</arg>
+			<arg type="a(ia{sv})" name="properties" direction="out" >
+				<dox:d>
+					An array of property values.
+					An item in this area is represented as a struct following
+					this format:
+					@li id unsigned the item id
+					@li properties map(string => variant) the requested item properties
+				</dox:d>
+			</arg>
+		</method>
+
+		<method name="GetProperty">
+			<dox:d>
+			  Get a signal property on a single item.  This is not useful if you're
+			  going to implement this interface, it should only be used if you're
+			  debugging via a commandline tool.
+			</dox:d>
+			<arg type="i" name="id" direction="in">
+				<dox:d>the id of the item which received the event</dox:d>
+			</arg>
+			<arg type="s" name="name" direction="in">
+				<dox:d>the name of the property to get</dox:d>
+			</arg>
+			<arg type="v" name="value" direction="out">
+				<dox:d>the value of the property</dox:d>
+			</arg>
+		</method>
+
+		<method name="Event">
+			<dox:d><![CDATA[
+			This is called by the applet to notify the application an event happened on a
+			menu item.
+
+			@a type can be one of the following:
+
+			@li "clicked"
+			@li "hovered"
+
+			Vendor specific events can be added by prefixing them with "x-<vendor>-"
+			]]></dox:d>
+			<arg type="i" name="id" direction="in" >
+				<dox:d>the id of the item which received the event</dox:d>
+			</arg>
+			<arg type="s" name="eventId" direction="in" >
+				<dox:d>the type of event</dox:d>
+			</arg>
+			<arg type="v" name="data" direction="in" >
+				<dox:d>event-specific data</dox:d>
+			</arg>
+			<arg type="u" name="timestamp" direction="in" >
+				<dox:d>The time that the event occured if available or the time the message was sent if not</dox:d>
+			</arg>
+		</method>
+
+		<method name="AboutToShow">
+			<dox:d>
+			This is called by the applet to notify the application that it is about
+			to show the menu under the specified item.
+			</dox:d>
+			<arg type="i" name="id" direction="in">
+				<dox:d>
+				Which menu item represents the parent of the item about to be shown.
+				</dox:d>
+			</arg>
+			<arg type="b" name="needUpdate" direction="out">
+				<dox:d>
+				Whether this AboutToShow event should result in the menu being updated.
+				</dox:d>
+			</arg>
+		</method>
+
+<!-- Signals -->
+		<signal name="ItemsPropertiesUpdated">
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusMenuItemList"/>
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="DBusMenuItemKeysList"/>
+			<dox:d>
+			Triggered when there are lots of property updates across many items
+			so they all get grouped into a single dbus message.  The format is
+			the ID of the item with a hashtable of names and values for those
+			properties.
+			</dox:d>
+			<arg type="a(ia{sv})" name="updatedProps" direction="out" />
+			<arg type="a(ias)" name="removedProps" direction="out" />
+		</signal>
+
+		<signal name="LayoutUpdated">
+			<dox:d>
+			Triggered by the application to notify display of a layout update, up to
+			revision
+			</dox:d>
+			<arg type="u" name="revision" direction="out" >
+				<dox:d>The revision of the layout that we're currently on</dox:d>
+			</arg>
+			<arg type="i" name="parent" direction="out" >
+				<dox:d>
+				If the layout update is only of a subtree, this is the
+				parent item for the entries that have changed.  It is zero if
+				the whole layout should be considered invalid.
+				</dox:d>
+			</arg>
+		</signal>
+		<signal name="ItemActivationRequested">
+			<dox:d>
+			  The server is requesting that all clients displaying this
+			  menu open it to the user.  This would be for things like
+			  hotkeys that when the user presses them the menu should
+			  open and display itself to the user.
+			</dox:d>
+			<arg type="i" name="id" direction="out" >
+				<dox:d>ID of the menu that should be activated</dox:d>
+			</arg>
+			<arg type="u" name="timestamp" direction="out" >
+				<dox:d>The time that the event occured</dox:d>
+			</arg>
+		</signal>
+
+<!-- End of interesting stuff -->
+
+	</interface>
+</node>

--- a/generator/src/main/resources/org.kde.StatusNotifierItem.xml
+++ b/generator/src/main/resources/org.kde.StatusNotifierItem.xml
@@ -1,0 +1,102 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.kde.StatusNotifierItem">
+
+    <property name="Category" type="s" access="read"/>
+    <property name="Id" type="s" access="read"/>
+    <property name="Title" type="s" access="read"/>
+    <property name="Status" type="s" access="read"/>
+    <property name="WindowId" type="i" access="read"/>
+
+    <!-- An additional path to add to the theme search path to find the icons specified above. -->
+    <property name="IconThemePath" type="s" access="read"/>
+    <property name="Menu" type="o" access="read"/>
+    <property name="ItemIsMenu" type="b" access="read"/>
+
+
+    <!-- main icon -->
+    <!-- names are preferred over pixmaps -->
+    <property name="IconName" type="s" access="read"/>
+
+    <!--struct containing width, height and image data-->
+    <property name="IconPixmap" type="a(iiay)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusImageVector"/>
+    </property>
+
+    <property name="OverlayIconName" type="s" access="read"/>
+
+    <property name="OverlayIconPixmap" type="a(iiay)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusImageVector"/>
+    </property>
+
+
+    <!-- Requesting attention icon -->
+    <property name="AttentionIconName" type="s" access="read"/>
+
+    <!--same definition as image-->
+    <property name="AttentionIconPixmap" type="a(iiay)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusImageVector"/>
+    </property>
+
+    <property name="AttentionMovieName" type="s" access="read"/>
+
+
+
+    <!-- tooltip data -->
+
+    <!--(iiay) is an image-->
+    <property name="ToolTip" type="(sa(iiay)ss)" access="read">
+      <annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusToolTipStruct"/>
+    </property>
+
+    <method name="ProvideXdgActivationToken">
+        <arg name="token" type="s" direction="in"/>
+    </method>
+
+    <!-- interaction: the systemtray wants the application to do something -->
+    <method name="ContextMenu">
+        <!-- we're passing the coordinates of the icon, so the app knows where to put the popup window -->
+        <arg name="x" type="i" direction="in"/>
+        <arg name="y" type="i" direction="in"/>
+    </method>
+
+    <method name="Activate">
+        <arg name="x" type="i" direction="in"/>
+        <arg name="y" type="i" direction="in"/>
+    </method>
+
+    <method name="SecondaryActivate">
+        <arg name="x" type="i" direction="in"/>
+        <arg name="y" type="i" direction="in"/>
+    </method>
+
+    <method name="Scroll">
+      <arg name="delta" type="i" direction="in"/>
+      <arg name="orientation" type="s" direction="in"/>
+    </method>
+
+    <!-- Signals: the client wants to change something in the status-->
+    <signal name="NewTitle">
+    </signal>
+
+    <signal name="NewIcon">
+    </signal>
+
+    <signal name="NewAttentionIcon">
+    </signal>
+
+    <signal name="NewOverlayIcon">
+    </signal>
+
+    <signal name="NewMenu">
+    </signal>
+
+    <signal name="NewToolTip">
+    </signal>
+
+    <signal name="NewStatus">
+      <arg name="status" type="s"/>
+    </signal>
+
+  </interface>
+</node>

--- a/generator/src/main/resources/org.kde.StatusNotifierWatcher.xml
+++ b/generator/src/main/resources/org.kde.StatusNotifierWatcher.xml
@@ -1,0 +1,42 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.kde.StatusNotifierWatcher">
+
+    <!-- methods -->
+    <method name="RegisterStatusNotifierItem">
+       <arg name="service" type="s" direction="in"/>
+    </method>
+
+    <method name="RegisterStatusNotifierHost">
+       <arg name="service" type="s" direction="in"/>
+    </method>
+
+
+    <!-- properties -->
+
+    <property name="RegisteredStatusNotifierItems" type="as" access="read">
+       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QStringList"/>
+    </property>
+
+    <property name="IsStatusNotifierHostRegistered" type="b" access="read"/>
+
+    <property name="ProtocolVersion" type="i" access="read"/>
+
+
+    <!-- signals -->
+
+    <signal name="StatusNotifierItemRegistered">
+        <arg type="s"/>
+    </signal>
+
+    <signal name="StatusNotifierItemUnregistered">
+        <arg type="s"/>
+    </signal>
+
+    <signal name="StatusNotifierHostRegistered">
+    </signal>
+
+    <signal name="StatusNotifierHostUnregistered">
+    </signal>
+  </interface>
+</node>

--- a/sdk/src/main/generated/com/canonical/Dbusmenu.java
+++ b/sdk/src/main/generated/com/canonical/Dbusmenu.java
@@ -1,0 +1,96 @@
+package com.canonical;
+
+import java.util.List;
+import org.freedesktop.dbus.annotations.DBusBoundProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+public interface Dbusmenu extends DBusInterface {
+
+    @DBusBoundProperty
+    UInt32 getVersion();
+
+    @DBusBoundProperty
+    String getStatus();
+
+    GetLayoutTuple<UInt32, GetLayoutLayoutStruct> GetLayout(int parentId, int recursionDepth, List<String> propertyNames);
+
+    List<GetGroupPropertiesPropertiesStruct> GetGroupProperties(List<Integer> ids, List<String> propertyNames);
+
+    Variant<?> GetProperty(int id, String name);
+
+    void Event(int id, String eventId, Variant<?> data, UInt32 timestamp);
+
+    boolean AboutToShow(int id);
+
+    public static class ItemsPropertiesUpdated extends DBusSignal {
+
+        private final List<ItemsPropertiesUpdatedUpdatedPropsStruct> updatedProps;
+        private final List<ItemsPropertiesUpdatedRemovedPropsStruct> removedProps;
+
+        public ItemsPropertiesUpdated(String path, List<ItemsPropertiesUpdatedUpdatedPropsStruct> updatedProps, List<ItemsPropertiesUpdatedRemovedPropsStruct> removedProps) throws DBusException {
+            super(path, updatedProps, removedProps);
+            this.updatedProps = updatedProps;
+            this.removedProps = removedProps;
+        }
+
+        public List<ItemsPropertiesUpdatedUpdatedPropsStruct> getUpdatedProps() {
+            return updatedProps;
+        }
+
+        public List<ItemsPropertiesUpdatedRemovedPropsStruct> getRemovedProps() {
+            return removedProps;
+        }
+
+    }
+
+    public static class LayoutUpdated extends DBusSignal {
+
+        private final UInt32 revision;
+        private final int parent;
+
+        public LayoutUpdated(String path, UInt32 revision, int parent) throws DBusException {
+            super(path, revision, parent);
+            this.revision = revision;
+            this.parent = parent;
+        }
+
+        public UInt32 getRevision() {
+            return revision;
+        }
+
+        public int getParent() {
+            return parent;
+        }
+
+    }
+
+    public static class ItemActivationRequested extends DBusSignal {
+
+        private final int id;
+        private final UInt32 timestamp;
+
+        public ItemActivationRequested(String path, int id, UInt32 timestamp) throws DBusException {
+            super(path, id, timestamp);
+            this.id = id;
+            this.timestamp = timestamp;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public UInt32 getTimestamp() {
+            return timestamp;
+        }
+
+    }
+
+}

--- a/sdk/src/main/generated/com/canonical/GetGroupPropertiesPropertiesStruct.java
+++ b/sdk/src/main/generated/com/canonical/GetGroupPropertiesPropertiesStruct.java
@@ -1,0 +1,30 @@
+package com.canonical;
+
+import java.util.Map;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+public class GetGroupPropertiesPropertiesStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final Map<String, Variant<?>> member1;
+
+    public GetGroupPropertiesPropertiesStruct(int member0, Map<String, Variant<?>> member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public Map<String, Variant<?>> getMember1() {
+        return member1;
+    }
+
+}

--- a/sdk/src/main/generated/com/canonical/GetLayoutLayoutStruct.java
+++ b/sdk/src/main/generated/com/canonical/GetLayoutLayoutStruct.java
@@ -1,0 +1,38 @@
+package com.canonical;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+public class GetLayoutLayoutStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final Map<String, Variant<?>> member1;
+    @Position(2)
+    private final List<Variant<?>> member2;
+
+    public GetLayoutLayoutStruct(int member0, Map<String, Variant<?>> member1, List<Variant<?>> member2) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public Map<String, Variant<?>> getMember1() {
+        return member1;
+    }
+
+    public List<Variant<?>> getMember2() {
+        return member2;
+    }
+
+}

--- a/sdk/src/main/generated/com/canonical/GetLayoutTuple.java
+++ b/sdk/src/main/generated/com/canonical/GetLayoutTuple.java
@@ -1,0 +1,36 @@
+package com.canonical;
+
+import org.freedesktop.dbus.Tuple;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class GetLayoutTuple<A, B> extends Tuple {
+    @Position(0)
+    private A revision;
+    @Position(1)
+    private B layout;
+
+    public GetLayoutTuple(A revision, B layout) {
+        this.revision = revision;
+        this.layout = layout;
+    }
+
+    public A getRevision() {
+        return revision;
+    }
+
+    public void setRevision(A revision) {
+        this.revision = revision;
+    }
+
+    public B getLayout() {
+        return layout;
+    }
+
+    public void setLayout(B layout) {
+        this.layout = layout;
+    }
+
+}

--- a/sdk/src/main/generated/com/canonical/ItemsPropertiesUpdatedRemovedPropsStruct.java
+++ b/sdk/src/main/generated/com/canonical/ItemsPropertiesUpdatedRemovedPropsStruct.java
@@ -1,0 +1,29 @@
+package com.canonical;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class ItemsPropertiesUpdatedRemovedPropsStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final List<String> member1;
+
+    public ItemsPropertiesUpdatedRemovedPropsStruct(int member0, List<String> member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public List<String> getMember1() {
+        return member1;
+    }
+
+}

--- a/sdk/src/main/generated/com/canonical/ItemsPropertiesUpdatedUpdatedPropsStruct.java
+++ b/sdk/src/main/generated/com/canonical/ItemsPropertiesUpdatedUpdatedPropsStruct.java
@@ -1,0 +1,30 @@
+package com.canonical;
+
+import java.util.Map;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+public class ItemsPropertiesUpdatedUpdatedPropsStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final Map<String, Variant<?>> member1;
+
+    public ItemsPropertiesUpdatedUpdatedPropsStruct(int member0, Map<String, Variant<?>> member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public Map<String, Variant<?>> getMember1() {
+        return member1;
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/PropertyAttentionIconPixmapStruct.java
+++ b/sdk/src/main/generated/org/kde/PropertyAttentionIconPixmapStruct.java
@@ -1,0 +1,36 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyAttentionIconPixmapStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final int member1;
+    @Position(2)
+    private final List<Byte> member2;
+
+    public PropertyAttentionIconPixmapStruct(int member0, int member1, List<Byte> member2) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public int getMember1() {
+        return member1;
+    }
+
+    public List<Byte> getMember2() {
+        return member2;
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/PropertyIconPixmapStruct.java
+++ b/sdk/src/main/generated/org/kde/PropertyIconPixmapStruct.java
@@ -1,0 +1,36 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyIconPixmapStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final int member1;
+    @Position(2)
+    private final List<Byte> member2;
+
+    public PropertyIconPixmapStruct(int member0, int member1, List<Byte> member2) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public int getMember1() {
+        return member1;
+    }
+
+    public List<Byte> getMember2() {
+        return member2;
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/PropertyOverlayIconPixmapStruct.java
+++ b/sdk/src/main/generated/org/kde/PropertyOverlayIconPixmapStruct.java
@@ -1,0 +1,36 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyOverlayIconPixmapStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final int member1;
+    @Position(2)
+    private final List<Byte> member2;
+
+    public PropertyOverlayIconPixmapStruct(int member0, int member1, List<Byte> member2) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public int getMember1() {
+        return member1;
+    }
+
+    public List<Byte> getMember2() {
+        return member2;
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/PropertyToolTipStruct.java
+++ b/sdk/src/main/generated/org/kde/PropertyToolTipStruct.java
@@ -1,0 +1,43 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyToolTipStruct extends Struct {
+    @Position(0)
+    private final String member0;
+    @Position(1)
+    private final List<PropertyToolTipStructStruct> member1;
+    @Position(2)
+    private final String member2;
+    @Position(3)
+    private final String member3;
+
+    public PropertyToolTipStruct(String member0, List<PropertyToolTipStructStruct> member1, String member2, String member3) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+        this.member3 = member3;
+    }
+
+    public String getMember0() {
+        return member0;
+    }
+
+    public List<PropertyToolTipStructStruct> getMember1() {
+        return member1;
+    }
+
+    public String getMember2() {
+        return member2;
+    }
+
+    public String getMember3() {
+        return member3;
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/PropertyToolTipStructStruct.java
+++ b/sdk/src/main/generated/org/kde/PropertyToolTipStructStruct.java
@@ -1,0 +1,36 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyToolTipStructStruct extends Struct {
+    @Position(0)
+    private final int member0;
+    @Position(1)
+    private final int member1;
+    @Position(2)
+    private final List<Byte> member2;
+
+    public PropertyToolTipStructStruct(int member0, int member1, List<Byte> member2) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+    }
+
+    public int getMember0() {
+        return member0;
+    }
+
+    public int getMember1() {
+        return member1;
+    }
+
+    public List<Byte> getMember2() {
+        return member2;
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/StatusNotifierItem.java
+++ b/sdk/src/main/generated/org/kde/StatusNotifierItem.java
@@ -1,0 +1,156 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusBoundProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+
+/**
+ * Auto-generated class.
+ */
+public interface StatusNotifierItem extends DBusInterface {
+
+    @DBusBoundProperty
+    String getCategory();
+
+    @DBusBoundProperty
+    String getId();
+
+    @DBusBoundProperty
+    String getTitle();
+
+    @DBusBoundProperty
+    String getStatus();
+
+    @DBusBoundProperty
+    int getWindowId();
+
+    @DBusBoundProperty
+    String getIconThemePath();
+
+    @DBusBoundProperty
+    DBusPath getMenu();
+
+    @DBusBoundProperty
+    boolean isItemIsMenu();
+
+    @DBusBoundProperty
+    String getIconName();
+
+    @DBusBoundProperty(type = PropertyIconPixmapType.class)
+    List<PropertyIconPixmapStruct> getIconPixmap();
+
+    @DBusBoundProperty
+    String getOverlayIconName();
+
+    @DBusBoundProperty(type = PropertyOverlayIconPixmapType.class)
+    List<PropertyOverlayIconPixmapStruct> getOverlayIconPixmap();
+
+    @DBusBoundProperty
+    String getAttentionIconName();
+
+    @DBusBoundProperty(type = PropertyAttentionIconPixmapType.class)
+    List<PropertyAttentionIconPixmapStruct> getAttentionIconPixmap();
+
+    @DBusBoundProperty
+    String getAttentionMovieName();
+
+    @DBusBoundProperty(type = PropertyToolTipStruct.class)
+    PropertyToolTipStruct getToolTip();
+
+    void ProvideXdgActivationToken(String token);
+
+    void ContextMenu(int x, int y);
+
+    void Activate(int x, int y);
+
+    void SecondaryActivate(int x, int y);
+
+    void Scroll(int delta, String orientation);
+
+    public static interface PropertyIconPixmapType extends TypeRef<List<PropertyIconPixmapStruct>> {
+
+    }
+
+    public static interface PropertyOverlayIconPixmapType extends TypeRef<List<PropertyOverlayIconPixmapStruct>> {
+
+    }
+
+    public static interface PropertyAttentionIconPixmapType extends TypeRef<List<PropertyAttentionIconPixmapStruct>> {
+
+    }
+
+    public static class NewTitle extends DBusSignal {
+
+        public NewTitle(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class NewIcon extends DBusSignal {
+
+        public NewIcon(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class NewAttentionIcon extends DBusSignal {
+
+        public NewAttentionIcon(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class NewOverlayIcon extends DBusSignal {
+
+        public NewOverlayIcon(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class NewMenu extends DBusSignal {
+
+        public NewMenu(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class NewToolTip extends DBusSignal {
+
+        public NewToolTip(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class NewStatus extends DBusSignal {
+
+        private final String status;
+
+        public NewStatus(String path, String status) throws DBusException {
+            super(path, status);
+            this.status = status;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+    }
+
+}

--- a/sdk/src/main/generated/org/kde/StatusNotifierWatcher.java
+++ b/sdk/src/main/generated/org/kde/StatusNotifierWatcher.java
@@ -1,0 +1,81 @@
+package org.kde;
+
+import java.util.List;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusBoundProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+
+/**
+ * Auto-generated class.
+ */
+public interface StatusNotifierWatcher extends DBusInterface {
+
+    void RegisterStatusNotifierItem(String service);
+
+    void RegisterStatusNotifierHost(String service);
+
+    @DBusBoundProperty(type = PropertyRegisteredStatusNotifierItemsType.class)
+    List<String> getRegisteredStatusNotifierItems();
+
+    @DBusBoundProperty
+    boolean isIsStatusNotifierHostRegistered();
+
+    @DBusBoundProperty
+    int getProtocolVersion();
+
+    public static interface PropertyRegisteredStatusNotifierItemsType extends TypeRef<List<String>> {
+
+    }
+
+    public static class StatusNotifierItemRegistered extends DBusSignal {
+
+        private final String arg0;
+
+        public StatusNotifierItemRegistered(String path, String arg0) throws DBusException {
+            super(path, arg0);
+            this.arg0 = arg0;
+        }
+
+        public String getArg0() {
+            return arg0;
+        }
+
+    }
+
+    public static class StatusNotifierItemUnregistered extends DBusSignal {
+
+        private final String arg0;
+
+        public StatusNotifierItemUnregistered(String path, String arg0) throws DBusException {
+            super(path, arg0);
+            this.arg0 = arg0;
+        }
+
+        public String getArg0() {
+            return arg0;
+        }
+
+    }
+
+    public static class StatusNotifierHostRegistered extends DBusSignal {
+
+        public StatusNotifierHostRegistered(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+    public static class StatusNotifierHostUnregistered extends DBusSignal {
+
+        public StatusNotifierHostUnregistered(String path) throws DBusException {
+            super(path);
+        
+        }
+
+    }
+
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenu.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenu.kt
@@ -1,0 +1,70 @@
+package com.zugaldia.stargate.sdk.status
+
+import com.canonical.Dbusmenu
+import com.canonical.GetGroupPropertiesPropertiesStruct
+import com.canonical.GetLayoutLayoutStruct
+import com.canonical.GetLayoutTuple
+import org.freedesktop.dbus.types.UInt32
+import org.freedesktop.dbus.types.Variant
+import org.slf4j.LoggerFactory
+
+/**
+ * Server-side implementation of the com.canonical.dbusmenu interface.
+ * Export this object at [DBUS_MENU_OBJECT_PATH] alongside the StatusNotifierItem,
+ * and return [DBUS_MENU_OBJECT_PATH] from [getMenu] so the tray host can find it.
+ */
+class StargateMenu(
+    private val items: List<StargateMenuItem>,
+    private val onMenuOpened: (() -> Unit)? = null,
+    private val onMenuClosed: (() -> Unit)? = null,
+) : Dbusmenu {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    // Wired by StargateStatusNotifierItem to consume the pending XDG activation token.
+    internal var tokenConsumer: () -> String? = { null }
+
+    override fun getVersion(): UInt32 = UInt32(DBUS_MENU_VERSION)
+
+    override fun getStatus(): String = "normal"
+
+    override fun GetLayout(
+        parentId: Int,
+        recursionDepth: Int,
+        propertyNames: List<String>
+    ): GetLayoutTuple<UInt32, GetLayoutLayoutStruct> {
+        val children = items.map { item -> Variant(item.toStruct(), "(ia{sv}av)") as Variant<*> }
+        val root = GetLayoutLayoutStruct(
+            0,
+            mapOf("children-display" to Variant("submenu", "s")),
+            children,
+        )
+
+        return GetLayoutTuple(UInt32(1), root)
+    }
+
+    override fun GetGroupProperties(
+        ids: List<Int>,
+        propertyNames: List<String>
+    ): List<GetGroupPropertiesPropertiesStruct> = items
+        .filter { it.id in ids }
+        .map { GetGroupPropertiesPropertiesStruct(it.id, it.toProperties()) }
+
+    override fun GetProperty(id: Int, name: String): Variant<*> =
+        items.find { it.id == id }?.toProperties()?.get(name) ?: Variant("", "s")
+
+    override fun Event(id: Int, eventId: String, data: Variant<*>, timestamp: UInt32) {
+        logger.info("Event: id=$id, eventId=$eventId")
+        when (eventId) {
+            "opened" -> onMenuOpened?.invoke()
+            "closed" -> onMenuClosed?.invoke()
+            "clicked" -> {
+                items.filterIsInstance<StargateMenuItem.Action>().find { it.id == id }?.onClick?.invoke(tokenConsumer)
+            }
+        }
+    }
+
+    override fun AboutToShow(id: Int): Boolean = false
+
+    override fun getObjectPath(): String = DBUS_MENU_OBJECT_PATH
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenuItem.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenuItem.kt
@@ -1,0 +1,44 @@
+package com.zugaldia.stargate.sdk.status
+
+import com.canonical.GetLayoutLayoutStruct
+import org.freedesktop.dbus.types.Variant
+
+/**
+ * Represents an item in a DBusMenu context menu.
+ */
+sealed class StargateMenuItem {
+    abstract val id: Int
+
+    /**
+     * A clickable menu entry with a text label.
+     * [onClick] is invoked on the D-Bus thread with a [tokenSupplier] that lazily consumes
+     * the pending XDG activation token. Call [tokenSupplier] from the GTK main thread
+     * (e.g. inside [org.gnome.glib.GLib.idleAdd]) to guarantee the token has been set by
+     * a concurrent [org.kde.StatusNotifierItem.ProvideXdgActivationToken] call.
+     */
+    data class Action(
+        override val id: Int,
+        val label: String,
+        val enabled: Boolean = true,
+        val onClick: (tokenSupplier: () -> String?) -> Unit,
+    ) : StargateMenuItem()
+
+    /** A visual separator between groups of items. */
+    data class Separator(override val id: Int) : StargateMenuItem()
+}
+
+fun StargateMenuItem.toStruct(): GetLayoutLayoutStruct =
+    GetLayoutLayoutStruct(id, toProperties(), emptyList())
+
+fun StargateMenuItem.toProperties(): Map<String, Variant<*>> = when (this) {
+    is StargateMenuItem.Action -> mapOf(
+        "type" to Variant("standard", "s"),
+        "label" to Variant(label, "s"),
+        "enabled" to Variant(enabled, "b"),
+        "visible" to Variant(true, "b"),
+    )
+    is StargateMenuItem.Separator -> mapOf(
+        "type" to Variant("separator", "s"),
+        "visible" to Variant(true, "b"),
+    )
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateStatusNotifierItem.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateStatusNotifierItem.kt
@@ -1,0 +1,109 @@
+package com.zugaldia.stargate.sdk.status
+
+import org.freedesktop.dbus.DBusPath
+import org.kde.PropertyAttentionIconPixmapStruct
+import org.kde.PropertyIconPixmapStruct
+import org.kde.PropertyOverlayIconPixmapStruct
+import org.kde.PropertyToolTipStruct
+import org.kde.StatusNotifierItem
+import org.slf4j.LoggerFactory
+
+/**
+ * Base class for StatusNotifierItem implementations. Handles the XDG activation token
+ * lifecycle and dispatches activate/secondary-activate callbacks. Subclasses provide
+ * application-specific identity and icon properties.
+ *
+ * @param menu Optional context menu exported via the com.canonical.dbusmenu protocol.
+ *   When provided, [getMenu] returns [DBUS_MENU_OBJECT_PATH] and the caller is responsible
+ *   for exporting the [StargateMenu] object at that path (see [StatusNotifierManager.registerItem]).
+ * @param onActivate Called on the D-Bus thread when the host activates the item (e.g. double-click).
+ *   Receives the XDG activation token (if any) provided by the host before the activate call.
+ *   Implementations must marshal any UI work to the GTK main thread themselves.
+ * @param onSecondaryActivate Called on the D-Bus thread when the host secondary-activates the item (e.g. middle-click).
+ *   Receives the XDG activation token (if any) provided by the host before the activate call.
+ *   Implementations must marshal any UI work to the GTK main thread themselves.
+ */
+@Suppress("TooManyFunctions")
+abstract class StargateStatusNotifierItem(
+    val menu: StargateMenu? = null,
+    private val onActivate: (token: String?) -> Unit,
+    private val onSecondaryActivate: (token: String?) -> Unit,
+) : StatusNotifierItem {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    init {
+        menu?.tokenConsumer = ::consumeActivationToken
+    }
+
+    @Volatile
+    private var pendingActivationToken: String? = null
+
+    private fun consumeActivationToken(): String? {
+        val token = pendingActivationToken
+        pendingActivationToken = null
+        return token
+    }
+
+    override fun getCategory(): String = "ApplicationStatus"
+
+    abstract override fun getId(): String
+
+    abstract override fun getTitle(): String
+
+    override fun getStatus(): String = "Active"
+
+    override fun getWindowId(): Int = 0
+
+    override fun getIconThemePath(): String = ""
+
+    override fun getMenu(): DBusPath = if (menu != null) DBusPath(DBUS_MENU_OBJECT_PATH) else DBusPath("/")
+
+    override fun isItemIsMenu(): Boolean = false
+
+    // https://specifications.freedesktop.org/icon-naming/latest/
+    override fun getIconName(): String = "dialog-information"
+
+    override fun getIconPixmap(): List<PropertyIconPixmapStruct> = emptyList()
+
+    override fun getOverlayIconName(): String = ""
+
+    override fun getOverlayIconPixmap(): List<PropertyOverlayIconPixmapStruct> = emptyList()
+
+    override fun getAttentionIconName(): String = ""
+
+    override fun getAttentionIconPixmap(): List<PropertyAttentionIconPixmapStruct> = emptyList()
+
+    override fun getAttentionMovieName(): String = ""
+
+    abstract fun getToolTipInfo(): Pair<String, String>
+
+    override fun getToolTip(): PropertyToolTipStruct {
+        val info = getToolTipInfo()
+        return PropertyToolTipStruct("", emptyList(), info.first, info.second)
+    }
+
+    override fun ProvideXdgActivationToken(token: String) {
+        logger.info("ProvideXdgActivationToken: $token")
+        pendingActivationToken = token
+    }
+
+    override fun ContextMenu(x: Int, y: Int) {
+        logger.info("ContextMenu: x=$x, y=$y")
+    }
+
+    override fun Activate(x: Int, y: Int) {
+        logger.info("Activate: x=$x, y=$y (token=$pendingActivationToken)")
+        onActivate(consumeActivationToken())
+    }
+
+    override fun SecondaryActivate(x: Int, y: Int) {
+        logger.info("SecondaryActivate: x=$x, y=$y (token=$pendingActivationToken)")
+        onSecondaryActivate(consumeActivationToken())
+    }
+
+    override fun Scroll(delta: Int, orientation: String) {
+        logger.info("Scroll: delta=$delta, orientation=$orientation")
+    }
+
+    override fun getObjectPath(): String = STATUS_NOTIFIER_ITEM_OBJECT_PATH
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StatusNotifierConstants.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StatusNotifierConstants.kt
@@ -1,0 +1,32 @@
+package com.zugaldia.stargate.sdk.status
+
+/**
+ * D-Bus bus name for the StatusNotifierWatcher.
+ */
+const val STATUS_NOTIFIER_BUS_NAME = "org.kde.StatusNotifierWatcher"
+
+/**
+ * D-Bus object path for the StatusNotifierWatcher.
+ */
+const val STATUS_NOTIFIER_OBJECT_PATH = "/StatusNotifierWatcher"
+
+/**
+ * D-Bus object path for the StatusNotifierItem exported by this process.
+ */
+const val STATUS_NOTIFIER_ITEM_OBJECT_PATH = "/StatusNotifierItem"
+
+/**
+ * Prefix for the well-known bus name claimed by a StatusNotifierItem.
+ * Full name: "$STATUS_NOTIFIER_ITEM_SERVICE_PREFIX-{pid}-1"
+ */
+const val STATUS_NOTIFIER_ITEM_SERVICE_PREFIX = "org.kde.StatusNotifierItem"
+
+/**
+ * D-Bus object path for the DBusMenu exported alongside a StatusNotifierItem.
+ */
+const val DBUS_MENU_OBJECT_PATH = "/StatusNotifierItem/Menu"
+
+/**
+ * com.canonical.dbusmenu protocol version implemented by this library.
+ */
+const val DBUS_MENU_VERSION = 3L

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StatusNotifierManager.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StatusNotifierManager.kt
@@ -1,0 +1,62 @@
+package com.zugaldia.stargate.sdk.status
+
+import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.kde.StatusNotifierWatcher
+
+/**
+ * Wrapper around the org.kde.StatusNotifierWatcher D-Bus interface.
+ * Provides access to the KDE StatusNotifier protocol for system tray integration.
+ */
+class StatusNotifierManager(private val connection: DBusConnection) : AutoCloseable {
+    private val watcher: StatusNotifierWatcher =
+        connection.getRemoteObject(
+            STATUS_NOTIFIER_BUS_NAME,
+            STATUS_NOTIFIER_OBJECT_PATH,
+            StatusNotifierWatcher::class.java
+        )
+
+    /**
+     * Returns true if a StatusNotifierHost is currently registered with the watcher.
+     */
+    fun isStatusNotifierHostRegistered(): Boolean = watcher.isIsStatusNotifierHostRegistered
+
+    /**
+     * Returns the protocol version supported by the StatusNotifierWatcher.
+     */
+    fun getProtocolVersion(): Int = watcher.protocolVersion
+
+    /**
+     * Returns the list of registered StatusNotifierItem service names.
+     */
+    fun getRegisteredStatusNotifierItems(): List<String> = watcher.registeredStatusNotifierItems
+
+    /**
+     * Exports a StatusNotifierItem on the session bus and registers it with the watcher.
+     * Returns the well-known service name that was claimed (e.g. "org.kde.StatusNotifierItem-1234-1").
+     */
+    fun registerItem(
+        item: StargateStatusNotifierItem,
+        identifier: String = STATUS_NOTIFIER_ITEM_SERVICE_PREFIX
+    ): String {
+        val pid = ProcessHandle.current().pid()
+        val serviceName = "$identifier-$pid-1"
+        connection.exportObject(STATUS_NOTIFIER_ITEM_OBJECT_PATH, item)
+        item.menu?.let { connection.exportObject(DBUS_MENU_OBJECT_PATH, it) }
+        connection.requestBusName(serviceName)
+        watcher.RegisterStatusNotifierItem(serviceName)
+        return serviceName
+    }
+
+    override fun close() {
+        connection.close()
+    }
+
+    companion object {
+        /**
+         * Creates a new StatusNotifierManager connected to the session bus.
+         */
+        fun connect(): StatusNotifierManager =
+            StatusNotifierManager(DBusConnectionBuilder.forSessionBus().build())
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the [Freedesktop Status Notifier Item Specification](https://specifications.freedesktop.org/status-notifier-item/0.1/index.html), enabling system tray icon integration from JVM applications on Linux.

**Generator / XML specs**
- Added XML specs for `org.kde.StatusNotifierItem`, `org.kde.StatusNotifierWatcher`, and `com.canonical.dbusmenu`
- Generated Java interfaces for all three specs
- Added `generate-status-notifier` make target and refactored shared generator setup

**SDK (`sdk/status/`)**
- `StatusNotifierManager` — connects to the session bus and registers an item with the `org.kde.StatusNotifierWatcher`
- `StargateStatusNotifierItem` — abstract base class implementing the KDE `StatusNotifierItem` interface, including XDG activation token lifecycle
- `StargateMenu` / `StargateMenuItem` — server-side `com.canonical.dbusmenu` implementation with `Action` and `Separator` item types
- `StatusNotifierConstants` — D-Bus paths and bus names

**App (`app/status/`)**
- `StatusNotifierItemStargate` — concrete SNI implementation for the demo app
- `StatusNotifierViewModel` — manages connection lifecycle and exposes immutable `StatusNotifierState` via GTK signals
- `StatusNotifierScreen` — GTK4 screen showing connection status and watcher info
- Menu includes Open, Item A/B/C, and Quit actions with XDG activation token support

**Other**
- `README.md` updated with Status Notifier section and fragmentation caveats
- Log level changed from `debug` to `info`

## Test plan

- [ ] `make build` passes
- [ ] `./gradlew detekt` passes
- [ ] Run `make run`, navigate to "Status Notifier" screen, click "Connect"
- [ ] Verify tray icon appears in system tray (requires a compatible desktop environment or the AppIndicator GNOME extension)
- [ ] Verify menu actions (Open, Quit, Item A/B/C) work correctly
- [ ] Verify window focus is restored on tray icon activation