### PR TITLE
Add Dokka 2.2.0 and publish SDK KDocs to GitHub Pages

### DIFF
--- a/.github/workflows/kdocs.yml
+++ b/.github/workflows/kdocs.yml
@@ -1,0 +1,49 @@
+name: KDocs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+      - name: Generate KDocs
+        env:
+          GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
+        run: ./gradlew :sdk:dokkaGenerate
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: sdk/build/dokka/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export JDK_JAVA_OPTIONS = --enable-native-access=ALL-UNNAMED
 
 .PHONY: run build check clean shadow-build shadow-run \
 	flatpak-sources flatpak-linter flatpak-build flatpak-bundle flatpak-run \
-	publish-local generate-java generate-status-notifier
+	publish-local generate-java generate-status-notifier kdocs
 
 run: clean
 	./gradlew :app:run
@@ -55,3 +55,6 @@ generate-java:
 
 generate-status-notifier:
 	./gradlew :generator:run --args="generate-status-notifier"
+
+kdocs:
+	./gradlew :sdk:dokkaGenerate

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ dependencies {
 }
 ```
 
-Check out the [included app](./app/src/main/kotlin/com/zugaldia/stargate/app) for working examples.
+Check out the [included app](./app/src/main/kotlin/com/zugaldia/stargate/app) for working examples,
+or browse the [API reference (KDocs)](https://zugaldia.github.io/stargate/).
 
 # Supported Portals
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ clikt = "5.1.0"
 dbusJavaV5 = "5.2.0"
 dbusJavaV6 = "6.0.0-SNAPSHOT"
 detekt = "2.0.0-alpha.2"
+dokka = "2.2.0"
 flatpakGradleGenerator = "1.7.0"
 javaGi = "0.14.1"
 kotlin = "2.3.10"
@@ -40,6 +41,7 @@ kotlinxEcosystem = ["kotlinxDatetime", "kotlinxSerialization", "kotlinxCoroutine
 
 [plugins]
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 flatpakGradleGenerator = { id = "io.github.jwharm.flatpak-gradle-generator", version.ref = "flatpakGradleGenerator" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 kotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     // The shared code is located in `buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts`.
     id("buildsrc.convention.kotlin-jvm")
     `java-library`
+    alias(libs.plugins.dokka)
     alias(libs.plugins.flatpakGradleGenerator)
     alias(libs.plugins.kotlinPluginSerialization)
     alias(libs.plugins.mavenPublish)
@@ -69,4 +70,15 @@ tasks.flatpakGradleGenerator {
     outputFile = file("flatpak-sources.json")
     downloadDirectory = "offline-repository"
     excludeConfigurations = listOf("testCompileClasspath", "testRuntimeClasspath")
+}
+
+dokka {
+    moduleName.set("Stargate SDK")
+    dokkaSourceSets.named("main") {
+        sourceLink {
+            localDirectory.set(file("src/main/kotlin"))
+            remoteUrl("https://github.com/zugaldia/stargate/tree/main/sdk/src/main/kotlin")
+            remoteLineSuffix.set("#L")
+        }
+    }
 }

--- a/sdk/flatpak-sources.json
+++ b/sdk/flatpak-sources.json
@@ -1,6 +1,566 @@
 [
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.15.3/jackson-annotations-2.15.3.jar",
+    "sha512": "c496afd736fa8acbf8126887e2ff375f162212f451326451fbb4b9194231d814e25bccacbaead9db98beec454f6b8d9ed706c5c88e2145bf7e1a37e13fd81af0",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.15.3",
+    "dest-filename": "jackson-annotations-2.15.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.15.3/jackson-annotations-2.15.3.module",
+    "sha512": "6ae8ed588ae75501a7651db339a1e04ed6e2d3128b37ecccb460cdc1fe36b01b88cd154c8421db4bb0d85bd871ef732f3824a0ff9abfdfabec5577dfba1c222e",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.15.3",
+    "dest-filename": "jackson-annotations-2.15.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-annotations/2.15.3/jackson-annotations-2.15.3.pom",
+    "sha512": "02df4d6ec464ffdd5f3b85a0b399fb0ce17f63748ac3de1b0ab22f1230497e75461b1cf4c1e8fbdb5390447a77b4d624f1f3150100a4572949bf5ec7e451f08b",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-annotations/2.15.3",
+    "dest-filename": "jackson-annotations-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.15.3/jackson-core-2.15.3.jar",
+    "sha512": "112de40a31dc7d011f256f1d2fe0d9e2afc301a1f31974318f8d070c3e362b2ba96005167384244f630b915451db6694bd3cf6a9b793872351bc18f21c9de5e4",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-core/2.15.3",
+    "dest-filename": "jackson-core-2.15.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.15.3/jackson-core-2.15.3.module",
+    "sha512": "0b8ecb10fe4895e22de3b59e79a4c3878295c0cc64a513169b95979b8de1ee3ab804d2f2fba7985b08a83fbad700ff9db54e0e69ce365ca115af0a8a2d712665",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-core/2.15.3",
+    "dest-filename": "jackson-core-2.15.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-core/2.15.3/jackson-core-2.15.3.pom",
+    "sha512": "743caf6d78a5c277f14f04c50f8d7ec5a806c2ed30077aeb04f2317c2ee272845c7858a8043fb20962565b6270333d76c11b9607b364c542f860f794973146f9",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-core/2.15.3",
+    "dest-filename": "jackson-core-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.15.3/jackson-databind-2.15.3.jar",
+    "sha512": "490ccc99a9c28238fe28455bae08196b83df034cae8a1947d27ff89e500a5d812cf4be36c61942e647c62ad540d8eb4428f49855f0cc8db0ee9e7a5b12ba2454",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-databind/2.15.3",
+    "dest-filename": "jackson-databind-2.15.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.15.3/jackson-databind-2.15.3.module",
+    "sha512": "710bcb1e35037581e2c5b99c3c45fa1a5d33ba8ab64b9e03e63049ceb8280354d4f60df2028270577c580491d652621dabff7fd970c7ee1bc49f8f567a12eb35",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-databind/2.15.3",
+    "dest-filename": "jackson-databind-2.15.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/core/jackson-databind/2.15.3/jackson-databind-2.15.3.pom",
+    "sha512": "e4aeb405bd638977d7b03af59cafdd60d2e748fe29478cb0fa95e5aefe1390882b7398776619792a2a0a70afd400ef696a40edd5b887dc5d559dcfd82dc5542a",
+    "dest": "offline-repository/com/fasterxml/jackson/core/jackson-databind/2.15.3",
+    "dest-filename": "jackson-databind-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-avro/2.15.3/jackson-dataformat-avro-2.15.3.pom",
+    "sha512": "55e0a3015c69a34484e7b0d44a3e3a3c503e3a3b088644f8e07ad961ff3b0f9ca5fbae2d0aff1f2923e27aab99a78bc01706c5667fd1df91ef66f48f6c168281",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-avro/2.15.3",
+    "dest-filename": "jackson-dataformat-avro-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.15.3/jackson-dataformat-cbor-2.15.3.pom",
+    "sha512": "cb372e1e843438233146473f864416c830118cfa84fa17b7d41263096df946aa9c8933f249f3ec7995489b4c9f1d2a3cf555448e971dae6576eb6ad813aacdf1",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.15.3",
+    "dest-filename": "jackson-dataformat-cbor-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-csv/2.15.3/jackson-dataformat-csv-2.15.3.pom",
+    "sha512": "c958d9522a1866a1d9d790c3eec96615cf46f3c3cd59a03d3487182aec492afb4a3e1cd7d22d70dd49cf67130ef8e50d4db2a6e74e0526d6901c9d5d7b5181d4",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-csv/2.15.3",
+    "dest-filename": "jackson-dataformat-csv-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-ion/2.15.3/jackson-dataformat-ion-2.15.3.pom",
+    "sha512": "3c13da0573fff06eb0e8aab9a7965b424ebd2ed82ce11cfc8c0c2d9165b5700767b94689912043c593afd556e64edc9c7896547b788fd65724d2eb3d931f9450",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-ion/2.15.3",
+    "dest-filename": "jackson-dataformat-ion-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-properties/2.15.3/jackson-dataformat-properties-2.15.3.pom",
+    "sha512": "e5142867bc27a1ed34f5fce75bcce0c9df6b07d67a75a6d3ce85c5e8c793b00212447ffc4eb9f7e027d9dfc350f6ae46489a19af0818591f6e70d1a566676526",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-properties/2.15.3",
+    "dest-filename": "jackson-dataformat-properties-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-protobuf/2.15.3/jackson-dataformat-protobuf-2.15.3.pom",
+    "sha512": "a27d6645e17df07b7bb0dd4f0510e775b5304a09065f1bb6638b7319ce6f8dbda638e4eccc4d5281dee6c6bac275c9714a9a542f65589da32b66cb7c0a3f7182",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-protobuf/2.15.3",
+    "dest-filename": "jackson-dataformat-protobuf-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.15.3/jackson-dataformat-smile-2.15.3.pom",
+    "sha512": "078e06f692e46687bb0a38c5dc51f6ec85ac2b2f2663342505b8b266c257fb27c448f2479b935d261d6676e98a7a1a9e65f3ac864629fb9c191f21f7068eb8cf",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.15.3",
+    "dest-filename": "jackson-dataformat-smile-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.15.3/jackson-dataformat-toml-2.15.3.pom",
+    "sha512": "98e8c1e10b7f32c56e91943578b5b3885e8acc984967b793a32fdf665520858f578068df2f7af6402bbf943631cb697b9801f3145ece5c7eefa107221a615ffc",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.15.3",
+    "dest-filename": "jackson-dataformat-toml-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.3/jackson-dataformat-xml-2.15.3.jar",
+    "sha512": "73914cde6694165a76f8f36e4611aa963dfa0dd5abebb34cd2efea938c839cbaad97d6786499bea1acf7bef12789797135b40e0f1bd3c3218cf4b830e494926f",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.3",
+    "dest-filename": "jackson-dataformat-xml-2.15.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.3/jackson-dataformat-xml-2.15.3.module",
+    "sha512": "b90f764f70d4343cfa7216bbd8e58b6bb72d8aa4d5dbad76821549c6799cf379689acf55132b130d762ab6a92aa3e6fab560e205ac34a268da9a3ca5f4715046",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.3",
+    "dest-filename": "jackson-dataformat-xml-2.15.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.3/jackson-dataformat-xml-2.15.3.pom",
+    "sha512": "3358b3a61f7a477d9d911eef0d4ab46aed6c7f3413e7687b413cd53aa46447d96b6b438c2854a33614ba5367e15f74a25004e2b9378a412d0a950b3a19dc32be",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.3",
+    "dest-filename": "jackson-dataformat-xml-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.15.3/jackson-dataformat-yaml-2.15.3.pom",
+    "sha512": "11f895c7537d844c47fc7bb6c6cc2f576ac69027a6ca14e8067a8cb96a6716a71b0d324ff76d8ecf3d336d427362b23b5aa43b44c859120318efeea425f10e9a",
+    "dest": "offline-repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.15.3",
+    "dest-filename": "jackson-dataformat-yaml-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-eclipse-collections/2.15.3/jackson-datatype-eclipse-collections-2.15.3.pom",
+    "sha512": "1ea985aef75833804d2ce01a7127b7f698264ce475cc293a7a8fbb2ba2e532d789666308a606f11a66dcd47bd741805ef6c2b7704d75d3961a89f426fd1a8c5f",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-eclipse-collections/2.15.3",
+    "dest-filename": "jackson-datatype-eclipse-collections-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-guava/2.15.3/jackson-datatype-guava-2.15.3.pom",
+    "sha512": "8eed75a9d29eb9cc9d7e766e2b638c18025b469fc5742714bc3f63b80ba4ad054f47c1cdcf15dd28f40e45d0c0a01a82ea6bcf817bceb33b6add41544808abc2",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-guava/2.15.3",
+    "dest-filename": "jackson-datatype-guava-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-hibernate4/2.15.3/jackson-datatype-hibernate4-2.15.3.pom",
+    "sha512": "ded1f970de5a65154220895bbffd270b629e5a6da100db9c84a4b9cd286ff82c2f81e9f870d83aefe8e96fdbecfd27a43317f83aa47c4daaf2376daf71d10c6c",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-hibernate4/2.15.3",
+    "dest-filename": "jackson-datatype-hibernate4-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-hibernate5-jakarta/2.15.3/jackson-datatype-hibernate5-jakarta-2.15.3.pom",
+    "sha512": "d2b9246b2b68408f843873ed5f5da73edbed27c61c0a185e9192e008516dc8839e3af9555bfd91bfc8d414193c99c78fb8966cc083b104490e9104ab29ae3c09",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-hibernate5-jakarta/2.15.3",
+    "dest-filename": "jackson-datatype-hibernate5-jakarta-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-hibernate5/2.15.3/jackson-datatype-hibernate5-2.15.3.pom",
+    "sha512": "5dee6e5a428b1d64fa5e8ba83e9fa559f1ed0faeb58b5b5da8d0e8e40ae9d349fb324928913c1a86c297c4317954979496bfdccca3b7acc8303740012a7879e5",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-hibernate5/2.15.3",
+    "dest-filename": "jackson-datatype-hibernate5-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-hibernate6/2.15.3/jackson-datatype-hibernate6-2.15.3.pom",
+    "sha512": "5d437d7d1cc6f2dff5316972c7b4bb7f338033a5a950c66754bad99db9f9bc9b34ceb7e5eed645f2b9027ce7697d51503836016ad52a9c593787d318c87f778a",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-hibernate6/2.15.3",
+    "dest-filename": "jackson-datatype-hibernate6-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-hppc/2.15.3/jackson-datatype-hppc-2.15.3.pom",
+    "sha512": "7f9b9afb52f59db2e9904bbd6a58063e8cfc19cffebcb3a4b2a7ed22a6e9e5c578e4a954b693cad174fe93d81455e80c4f5e4a87b61bbef5dcb780135ec3a6e9",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-hppc/2.15.3",
+    "dest-filename": "jackson-datatype-hppc-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jakarta-jsonp/2.15.3/jackson-datatype-jakarta-jsonp-2.15.3.pom",
+    "sha512": "8716b76813cfe5797b0109c571c8eb2db84a43b7ef839505658ed79df8731c1b4bbb84b8a1dfb337cffef6eac15bebf6874d74c73403152deeae3e600896011e",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jakarta-jsonp/2.15.3",
+    "dest-filename": "jackson-datatype-jakarta-jsonp-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jaxrs/2.15.3/jackson-datatype-jaxrs-2.15.3.pom",
+    "sha512": "35caa8f83aec092051f251e09ef6bffc85b19c41c8667dc58854b345a92610bb1f7ba9d925bbbe0c8f2cd13e1f2869cd3e509ca0804fa10546ec44d9d048db6a",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jaxrs/2.15.3",
+    "dest-filename": "jackson-datatype-jaxrs-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.15.3/jackson-datatype-jdk8-2.15.3.pom",
+    "sha512": "023834b0ee8bbd15d6c28e6e9e271775e38e62cbf9cdd4c416dcbdcb6b93394d1452138546b42b1c6f601841ba6e493cc7a112e98c7c05384988f394e8ba3d74",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.15.3",
+    "dest-filename": "jackson-datatype-jdk8-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-joda-money/2.15.3/jackson-datatype-joda-money-2.15.3.pom",
+    "sha512": "1a99357ee270ed52e6107427b5f9a6688c57240d1639aa4b735021a9cd11b86f8b3362525a0cfb317834aefe327c158c43606967562fb6b14d30b822455efc6f",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-joda-money/2.15.3",
+    "dest-filename": "jackson-datatype-joda-money-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-joda/2.15.3/jackson-datatype-joda-2.15.3.pom",
+    "sha512": "be4a4efcf2eb72e1da1f2ae6f613810023ceeba859c605f8b6abd37debedd2127234258a3e8ad87dd8ce4ebc95fef2f35cbb9fd690ac025e5ad58ca41e3d42f5",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-joda/2.15.3",
+    "dest-filename": "jackson-datatype-joda-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-json-org/2.15.3/jackson-datatype-json-org-2.15.3.pom",
+    "sha512": "ce2d1eb2b0e72438893cbf6894885ad246aa7ae00f284c5917091f3d005f5746e23e82939e7e6b77a1985336b01ba65773645863814e4f333a8fb8dfcbfeca39",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-json-org/2.15.3",
+    "dest-filename": "jackson-datatype-json-org-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.15.3/jackson-datatype-jsr310-2.15.3.pom",
+    "sha512": "988b655dfa4ef1610a39b2dbc8158ac4803b51a310e6197bd43c36c8ac699b684cf0601ee756816970722de96d7b6337b339e6b51e8558dbc2ccc555399da73d",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.15.3",
+    "dest-filename": "jackson-datatype-jsr310-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-jsr353/2.15.3/jackson-datatype-jsr353-2.15.3.pom",
+    "sha512": "2aafb307102439467591eb7a8646ff904949780a64643eacf07c07be414eefe09ee29cbe527717ece521bc1939605c8938178120b2d02ada3ce8adaea11e9671",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr353/2.15.3",
+    "dest-filename": "jackson-datatype-jsr353-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/datatype/jackson-datatype-pcollections/2.15.3/jackson-datatype-pcollections-2.15.3.pom",
+    "sha512": "3c819d52c85fe7121aa60d07d24708d8e3f89529b1428644a6b01318ae651347f738f7df2a6c2feaa66801b48b93dd5ca48b3a8b02738a1fc3d000b7bc56eebd",
+    "dest": "offline-repository/com/fasterxml/jackson/datatype/jackson-datatype-pcollections/2.15.3",
+    "dest-filename": "jackson-datatype-pcollections-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-base/2.15.3/jackson-base-2.15.3.pom",
+    "sha512": "5c659e3da9a5f33d5f221ce469a9982fa46a9d198c44c71df470a467a152d1f5e4cf96ed9a95accdd0dbc869f7f24e63130d7a30e0ff2ae32a7ad75e02deb9a0",
+    "dest": "offline-repository/com/fasterxml/jackson/jackson-base/2.15.3",
+    "dest-filename": "jackson-base-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-bom/2.15.3/jackson-bom-2.15.3.pom",
+    "sha512": "81a693de24d0b05461b95577ab0e17414efe833062b24592b356d3216a59a663cbb8866916ba2d1e29c9609eafab0e6ded4fa3e924ec5e6771f4f020e148ed97",
+    "dest": "offline-repository/com/fasterxml/jackson/jackson-bom/2.15.3",
+    "dest-filename": "jackson-bom-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.15/jackson-parent-2.15.pom",
+    "sha512": "7edb6a94ba8b34077561744aafe9cd24e90d28268d447a9a260c0bb585125e77fdcaa8a301559ddf47b8774702cd292f9dc9c70e4e74dd45b091d09ee3494cf8",
+    "dest": "offline-repository/com/fasterxml/jackson/jackson-parent/2.15",
+    "dest-filename": "jackson-parent-2.15.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-base/2.15.3/jackson-jakarta-rs-base-2.15.3.pom",
+    "sha512": "e4d0667c9350c4bbbc056f16c2ed34d2ca1be597a819f66105301f3b57fca54ee106768b24b0dce6f7cddde06699916722bc457b189579ca6016c127a1de42a0",
+    "dest": "offline-repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-base/2.15.3",
+    "dest-filename": "jackson-jakarta-rs-base-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-cbor-provider/2.15.3/jackson-jakarta-rs-cbor-provider-2.15.3.pom",
+    "sha512": "b72f1c9d95503a45f21afb4606904222f4594494de82f63936be8d761f38c27c5e1c3206f6a3123511d9096a656a47d4aee07a014648eb981b45a1ebf4f6c42e",
+    "dest": "offline-repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-cbor-provider/2.15.3",
+    "dest-filename": "jackson-jakarta-rs-cbor-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-json-provider/2.15.3/jackson-jakarta-rs-json-provider-2.15.3.pom",
+    "sha512": "f4bc65ea7326e65a6778caf7e3c62a8dfa3176aa7a7e01aca7e4be89f3ebd0f41e65cd6c9698ec51b58eec3edbdc09d837e65e5d956320ce30a029f96e781bbb",
+    "dest": "offline-repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-json-provider/2.15.3",
+    "dest-filename": "jackson-jakarta-rs-json-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-smile-provider/2.15.3/jackson-jakarta-rs-smile-provider-2.15.3.pom",
+    "sha512": "2145f5fd804c36e124657139936d43bda18001754a29eb8dd74c6f455270fa89f403a19f0be2291c1874f4d57c27b00be8223b628346db98b405856be455a20e",
+    "dest": "offline-repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-smile-provider/2.15.3",
+    "dest-filename": "jackson-jakarta-rs-smile-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-xml-provider/2.15.3/jackson-jakarta-rs-xml-provider-2.15.3.pom",
+    "sha512": "e6eec60d9df079a4e2ed7006735e4198feb2721572e99a3ac2dfb8a67a9cc6c4cbab3fc15b4ab094f63f3c88632d0c7b7fb01fbeb69ab13a855bbb7d4195b128",
+    "dest": "offline-repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-xml-provider/2.15.3",
+    "dest-filename": "jackson-jakarta-rs-xml-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-yaml-provider/2.15.3/jackson-jakarta-rs-yaml-provider-2.15.3.pom",
+    "sha512": "1f8dee3d1b62fbc1f2ee375f06b0d05948504753534c8545d42804acbd29391a5fdad985a77e689435af8a9295f9151db85952c874ea11a6d68d2096707a6209",
+    "dest": "offline-repository/com/fasterxml/jackson/jakarta/rs/jackson-jakarta-rs-yaml-provider/2.15.3",
+    "dest-filename": "jackson-jakarta-rs-yaml-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.15.3/jackson-jaxrs-base-2.15.3.pom",
+    "sha512": "5c7fc03b222479feefc515a09377dd87bf0f4309e1ea02fee7b96d48f320a5c9c64a2264b3de638e6d3d391fc3a4c09e17d6ee82139851ec34dcaa5227ab5325",
+    "dest": "offline-repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.15.3",
+    "dest-filename": "jackson-jaxrs-base-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-cbor-provider/2.15.3/jackson-jaxrs-cbor-provider-2.15.3.pom",
+    "sha512": "adda3e119d9f4cbdf4ad9421d135fa2b0205db8648dc624a40a734dddcd360d5cddb5f43de303827ad39dc0612e89781defb50d670cdb2c8381d023b61e94285",
+    "dest": "offline-repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-cbor-provider/2.15.3",
+    "dest-filename": "jackson-jaxrs-cbor-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.15.3/jackson-jaxrs-json-provider-2.15.3.pom",
+    "sha512": "c7c04cc6de0e997e916be3e77fcfafc04dcff0fdb159583c930dcf67a15abcc978e3d138bd635232a055f3f5ddf8ee7d091b91c7a4c0d8294897b009b90647f7",
+    "dest": "offline-repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.15.3",
+    "dest-filename": "jackson-jaxrs-json-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-smile-provider/2.15.3/jackson-jaxrs-smile-provider-2.15.3.pom",
+    "sha512": "62d2f881f9e4850d420057b2c291ba42a29ae1af6dfbafefa3d4610781f77fb10b0c45183aa326fbc8eec05278c52a918107abe6a170d5b60478075caece6aab",
+    "dest": "offline-repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-smile-provider/2.15.3",
+    "dest-filename": "jackson-jaxrs-smile-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-xml-provider/2.15.3/jackson-jaxrs-xml-provider-2.15.3.pom",
+    "sha512": "eb965f314fb8ab21dfd2df8a8678f6283736623da994a6c42870300c0491596454354d03d6fba766c5087108d2e3e0547b2ca0466694df469cfbb11a84f2e8cc",
+    "dest": "offline-repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-xml-provider/2.15.3",
+    "dest-filename": "jackson-jaxrs-xml-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jaxrs/jackson-jaxrs-yaml-provider/2.15.3/jackson-jaxrs-yaml-provider-2.15.3.pom",
+    "sha512": "ad9b22e0c5fceb4b3a9c1f2f7b08dd5a49bf1cb5ea3e37ac710f4f049541bf71f6096e381c3b361ca330b1df12819831a5539deca689157276708137ace67fcb",
+    "dest": "offline-repository/com/fasterxml/jackson/jaxrs/jackson-jaxrs-yaml-provider/2.15.3",
+    "dest-filename": "jackson-jaxrs-yaml-provider-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jr/jackson-jr-all/2.15.3/jackson-jr-all-2.15.3.pom",
+    "sha512": "50637a7973db8c254c8e5d275da89559ef49913d443282d9752022c2aa48f0c0ff50a90f5d7426cb955d6b0f91e49d78488b9febddd4fca999224df3833d1249",
+    "dest": "offline-repository/com/fasterxml/jackson/jr/jackson-jr-all/2.15.3",
+    "dest-filename": "jackson-jr-all-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jr/jackson-jr-annotation-support/2.15.3/jackson-jr-annotation-support-2.15.3.pom",
+    "sha512": "0a0008f7afebfeb7bcdf382474948afb97d52089e04741300e13b19235044aa171dd584062698c41979670afb94c0d9bdfdcce41c344eab6d44c2a7ad0a5dab7",
+    "dest": "offline-repository/com/fasterxml/jackson/jr/jackson-jr-annotation-support/2.15.3",
+    "dest-filename": "jackson-jr-annotation-support-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jr/jackson-jr-objects/2.15.3/jackson-jr-objects-2.15.3.pom",
+    "sha512": "84685c6f102a669d5bd61f8cd1c4e2203ad3e4145508cad8e2b060478e6e35aeb50693493a58fa4536e9e0a9fed99c8d0bca633a16fcad8fb712f2fa9dcdd962",
+    "dest": "offline-repository/com/fasterxml/jackson/jr/jackson-jr-objects/2.15.3",
+    "dest-filename": "jackson-jr-objects-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jr/jackson-jr-retrofit2/2.15.3/jackson-jr-retrofit2-2.15.3.pom",
+    "sha512": "ee6c25ffe8a2e3c49bbdff507c95e71ae3a7f8196f5d1fc5014b8aa8c639a7baddf55d2c5d9cc5fcf8ad357154a88c224f30688a7c40aa584a0d97e1fae8f6e1",
+    "dest": "offline-repository/com/fasterxml/jackson/jr/jackson-jr-retrofit2/2.15.3",
+    "dest-filename": "jackson-jr-retrofit2-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/jr/jackson-jr-stree/2.15.3/jackson-jr-stree-2.15.3.pom",
+    "sha512": "fe1431a386218e4461fd32303c9433868ba77f7561225eb10afdb7fbe04c47e93821e20be4d0003cacbf8fa31cd4e870679b6244bc31b2d11736cadf66e9408d",
+    "dest": "offline-repository/com/fasterxml/jackson/jr/jackson-jr-stree/2.15.3",
+    "dest-filename": "jackson-jr-stree-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-afterburner/2.15.3/jackson-module-afterburner-2.15.3.pom",
+    "sha512": "89b25781b3e8b7f32ebe76d36693c5e26c7d98226af140e7033298a911700aa1ddae2ba0a1d3009df712091deab107dced891158387590acfa98a54bf555692e",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-afterburner/2.15.3",
+    "dest-filename": "jackson-module-afterburner-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-blackbird/2.15.3/jackson-module-blackbird-2.15.3.pom",
+    "sha512": "6a1895074ffa57e6b95ca87431a9dd50862e1aa14cb60df7b514bc8d05a8b33354cec9429f5b77083d4cc916e1204d3c9fb695e6b6d3b96ba4826b7c3ffa2245",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-blackbird/2.15.3",
+    "dest-filename": "jackson-module-blackbird-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-guice/2.15.3/jackson-module-guice-2.15.3.pom",
+    "sha512": "7f113ee0a14810c0c23eb18455e047b93ca90154fa5bbeae7d8ca3d0c2b49eeeee9aaf6f62620314c3c91c94b449e88ce14b51be1cd742d501c309c3fbe880dc",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-guice/2.15.3",
+    "dest-filename": "jackson-module-guice-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-jakarta-xmlbind-annotations/2.15.3/jackson-module-jakarta-xmlbind-annotations-2.15.3.pom",
+    "sha512": "020176e3404abe8a587cd9ab38fa040fe2ef9226430df823bf4c830b60dfdb9d732070645241ea991ac9c041dcc10dd3e53b7d8dac5ec064bf16d24480cdb8a9",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-jakarta-xmlbind-annotations/2.15.3",
+    "dest-filename": "jackson-module-jakarta-xmlbind-annotations-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.15.3/jackson-module-jaxb-annotations-2.15.3.pom",
+    "sha512": "79b1cadb83abbe0a9dbe56cf7a151c37bb5582f3ff2b167f8e2fb502b9b1dc6814ffde5734f692b7daf28c5b4bfaa813142f07e46aed8950f84c4f7f4499a6d5",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.15.3",
+    "dest-filename": "jackson-module-jaxb-annotations-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-jsonSchema-jakarta/2.15.3/jackson-module-jsonSchema-jakarta-2.15.3.pom",
+    "sha512": "f13017e8dd8f970cc04895a934991c14e6e8a9a7fd600448f23fbc46a73690b5a75d1e336cba69728a0c15c55317cb9af0a7b25f699f0aa9d2bbe5511c57361b",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-jsonSchema-jakarta/2.15.3",
+    "dest-filename": "jackson-module-jsonSchema-jakarta-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-jsonSchema/2.15.3/jackson-module-jsonSchema-2.15.3.pom",
+    "sha512": "7844a18ee01d7e866e34e3aeb4f2e4d47861a91d65c9443006a4e1b8419b8933237abb733a94060e531ea4666e15f30b7d68f112cc01ab2e78fd5ac55bf676b6",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-jsonSchema/2.15.3",
+    "dest-filename": "jackson-module-jsonSchema-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.15.3/jackson-module-kotlin-2.15.3.jar",
+    "sha512": "2e098c5ec94c2b5f90aff5b617295db705c92437e07eeaa62fbd53a3946ef2f92672439d1e6f2d7dd8ed0d75507321a01abdc55364d87c7db7922f1e2f7728bc",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.15.3",
+    "dest-filename": "jackson-module-kotlin-2.15.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.15.3/jackson-module-kotlin-2.15.3.module",
+    "sha512": "b2bfcc452fe41b03732140e931e213e1159dff0990ec944d92df70cc01f6327d7dc39c5a96862e4201eba579c339f91153a229ea405ac2819772b730a2dbd139",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.15.3",
+    "dest-filename": "jackson-module-kotlin-2.15.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-kotlin/2.15.3/jackson-module-kotlin-2.15.3.pom",
+    "sha512": "d57dc9c9789fbbfb8668cf23bccb424a3a99850eff26937778b575699e98a799b23c3fe7be3bd24f9120d637beb4bcc60167e8cddbf49a97392005720336f29c",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-kotlin/2.15.3",
+    "dest-filename": "jackson-module-kotlin-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-mrbean/2.15.3/jackson-module-mrbean-2.15.3.pom",
+    "sha512": "eb02ebbd7163925b9d05964432f93f211db706141f6b3c5d7b4b76ef2f0883b634469671e68e9c4a40bace98a6e5a042653a5688f07c383643a0fb5a87c08fb8",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-mrbean/2.15.3",
+    "dest-filename": "jackson-module-mrbean-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-no-ctor-deser/2.15.3/jackson-module-no-ctor-deser-2.15.3.pom",
+    "sha512": "be2bd9544d4252b20761ad11c9f46df605aee1ee6526bab4aaccee9bef4292d83f70462f52b4631f21bb336976f09dcc44f23cb4475bbc70a2051215c527f6c5",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-no-ctor-deser/2.15.3",
+    "dest-filename": "jackson-module-no-ctor-deser-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-osgi/2.15.3/jackson-module-osgi-2.15.3.pom",
+    "sha512": "93e136fec4b81a44bcd09027adfef907eefd3ef78163a381e58b7090df04e58189c09aceaceec7308d497d8765c4b215599ec5afd81c93c54dd055fb68a9c1f4",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-osgi/2.15.3",
+    "dest-filename": "jackson-module-osgi-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-parameter-names/2.15.3/jackson-module-parameter-names-2.15.3.pom",
+    "sha512": "43e836bf85e0fbc612e35c80a3fe3b9273c6c0ef4912129898f820c7eca068858bbcae427e27e892824cbe326099d5ef3d43c15b2932f31cf2958e61904260fa",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-parameter-names/2.15.3",
+    "dest-filename": "jackson-module-parameter-names-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-paranamer/2.15.3/jackson-module-paranamer-2.15.3.pom",
+    "sha512": "11b3e34706d712f5b3d9af6f60585a5ae94457ee2e890649195501e924ec50ff7314f8765257f660f098164746e6956d2c7a2b87c9f218c4090c1df76baf92a0",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-paranamer/2.15.3",
+    "dest-filename": "jackson-module-paranamer-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-scala_2.11/2.15.3/jackson-module-scala_2.11-2.15.3.pom",
+    "sha512": "c3cb465193e3c93302624d5b71031828ed7bc5b45b5a79e1fd9195c8b9f295223bdba9353c7818aa8008bfc2af48d42355bd82c918e852bb757f240ba4626b88",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-scala_2.11/2.15.3",
+    "dest-filename": "jackson-module-scala_2.11-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.15.3/jackson-module-scala_2.12-2.15.3.pom",
+    "sha512": "b691044cd9c9ab2532e9d9ecb7660dcb4be386953eb2aea9ba94e83b0ceffaefdc1141ef7913d6ef20acbf790a73bea2c7a478428249eb4ca477953ee457a57d",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.15.3",
+    "dest-filename": "jackson-module-scala_2.12-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-scala_2.13/2.15.3/jackson-module-scala_2.13-2.15.3.pom",
+    "sha512": "40b25a559a54a84ade11e28bd69d76b370af56fe26e61d3b94ee2b8ce9aeeb909eccd94a9dc80ce2ecfb425319c497874c4c52cf57e7ab83a9981d1095c4b54f",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-scala_2.13/2.15.3",
+    "dest-filename": "jackson-module-scala_2.13-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/jackson/module/jackson-module-scala_3/2.15.3/jackson-module-scala_3-2.15.3.pom",
+    "sha512": "fa8474b4767b95c1c8e8da32bfb9b18afdd939328c078f9643ba702043e28a29109d2618ccb69c153208d47f46c725fe2a12c289cbfb5f105a51ce53490c3596",
+    "dest": "offline-repository/com/fasterxml/jackson/module/jackson-module-scala_3/2.15.3",
+    "dest-filename": "jackson-module-scala_3-2.15.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/38/oss-parent-38.pom",
+    "sha512": "aa6deb3b068d3fc1a3fc3345a6f7e9d2e0479f6a1e8172966b19a89f64b221f0d52b24baf1f1eaff5399fb8b10595f4db2401483ac420312afda9a72b3efde1a",
+    "dest": "offline-repository/com/fasterxml/oss-parent/38",
+    "dest-filename": "oss-parent-38.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/oss-parent/50/oss-parent-50.pom",
+    "sha512": "b50fb8abbc07abe3bdca3fba18303d39095da498cace7bbc601c41563ef10cd5dd464b3ae0b838fb31b8d655f4aae76065bbd32d6b4fa9bea13515619249b860",
+    "dest": "offline-repository/com/fasterxml/oss-parent/50",
+    "dest-filename": "oss-parent-50.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/woodstox/woodstox-core/6.5.1/woodstox-core-6.5.1.jar",
+    "sha512": "d9b3cf6aaac85d8c349e7a24ad30f7e23b7765f1b7ce2fdf301bf2240b9c7ee184bdd938e58be6df9ac90e97e3b8c7b34f8fa9da27d1ed8de78765a8345b18f2",
+    "dest": "offline-repository/com/fasterxml/woodstox/woodstox-core/6.5.1",
+    "dest-filename": "woodstox-core-6.5.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/com/fasterxml/woodstox/woodstox-core/6.5.1/woodstox-core-6.5.1.pom",
+    "sha512": "ff80689bee27eee1be17448a7f2d04102814e6f1e30c5443a2f340e38b274ca7596c057c363f772c83aae0881f5985025e2b9ceb3fc5b86cd52174d69c280edd",
+    "dest": "offline-repository/com/fasterxml/woodstox/woodstox-core/6.5.1",
+    "dest-filename": "woodstox-core-6.5.1.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/com/github/ben-manes/gradle-versions-plugin/0.53.0/gradle-versions-plugin-0.53.0.jar",
     "sha512": "c28e3bcf6d8e8cd54086d52665474156962d211e9861785ef0b1ecab3272f8baba5ba9900293362f788163381276d9d2f502a69a05cd07eccb51d015ae36419a",
     "dest": "offline-repository/com/github/ben-manes/gradle-versions-plugin/0.53.0",
@@ -981,6 +1541,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/apache/apache/17/apache-17.pom",
+    "sha512": "1f46cdfd0b29f7faabe6b0c3ec096408d52cf321db81100e69b737443f2b9e71b68a3bfa8f64e318c16859e2de8daafbf40bb0c375c10354a892217cfeee5bec",
+    "dest": "offline-repository/org/apache/apache/17",
+    "dest-filename": "apache-17.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/bouncycastle/bcpg-jdk18on/1.80/bcpg-jdk18on-1.80.jar",
     "sha512": "a3d5da12f5ecb0fadff7b4966a6aef8a814b40313d216f831b3d9a478921164e1a43feae8530875a1b19cdfef55bce49d9d791db74c230f4f6c052fad5d3d163",
     "dest": "offline-repository/org/bouncycastle/bcpg-jdk18on/1.80",
@@ -1037,6 +1604,34 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/woodstox/stax2-api/4.2.1/stax2-api-4.2.1.jar",
+    "sha512": "00efc5d4d17540fb180c5b20d456630a8b3262dff46676689ae916ba16f0fbd9b1a71c7badfb254faad6597f94fed1edb96f77c15f40178eaf4d8cd35cea5e8d",
+    "dest": "offline-repository/org/codehaus/woodstox/stax2-api/4.2.1",
+    "dest-filename": "stax2-api-4.2.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/codehaus/woodstox/stax2-api/4.2.1/stax2-api-4.2.1.pom",
+    "sha512": "cc28523a10e5e40efa5ca2994b5c4b104caaf1617efaabe465a3f38b5eccd612828c5ee528c6871d5f5ca91a571900cd8d1f75db1960642355cc964fa0a4cab8",
+    "dest": "offline-repository/org/codehaus/woodstox/stax2-api/4.2.1",
+    "dest-filename": "stax2-api-4.2.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
+    "sha512": "934c6c2bf47c1b88b1f81c25294cd83f5105f90f565e1fce75a09a54e51424fb8335542a6d5c3eb9df19dbc0007e869e9b6aebaf37880eac09759529dc0c5ca7",
+    "dest": "offline-repository/org/freemarker/freemarker/2.3.32",
+    "dest-filename": "freemarker-2.3.32.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.pom",
+    "sha512": "4ac2a905f63f0bb870843564f87f5c71b045bc094cc3226dd87e9273e150abf97b17b83aa99da6727ee93e87b0e71254a0b5ff90ef0cf4aa75b643c95371394b",
+    "dest": "offline-repository/org/freemarker/freemarker/2.3.32",
+    "dest-filename": "freemarker-2.3.32.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jcommander/jcommander/1.85/jcommander-1.85.jar",
     "sha512": "aa1d19723c83de1f54f6f645121ab283403ece5ba78319c9daa4418c421e26c7fbd8bc36d35f6ed4cd9b8ae25d6daa2bc36818a1659cec8c5550441d6fb609d0",
     "dest": "offline-repository/org/jcommander/jcommander/1.85",
@@ -1083,6 +1678,132 @@
     "sha512": "ae58d75b40e44cb0d8e3bb701c7afefa8cbf96066ae52fc3d57c69b7a7e819fd9b3b01971376da6ea94ee010b9ee59ba05a331b93a65e94c047b095131efd6c0",
     "dest": "offline-repository/org/jetbrains/annotations/23.0.0",
     "dest-filename": "annotations-23.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/analysis-kotlin-symbols/2.2.0/analysis-kotlin-symbols-2.2.0.jar",
+    "sha512": "1df9e622b3a2d5c854d688de2273d64fc9e172b5cf0c46d1abbc0a008ddaa3cf51c8baaf31b70fecb5e987c4608722664152ab8efc9932141be45c7b8649f3f7",
+    "dest": "offline-repository/org/jetbrains/dokka/analysis-kotlin-symbols/2.2.0",
+    "dest-filename": "analysis-kotlin-symbols-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/analysis-kotlin-symbols/2.2.0/analysis-kotlin-symbols-2.2.0.pom",
+    "sha512": "521e483c0fb50441373e307171337621d264fee2f1823af280e095c78d27656c6ac4b5b3bb615c2220f48d539e0320ac9c94efe84671713858ed1cb49696486e",
+    "dest": "offline-repository/org/jetbrains/dokka/analysis-kotlin-symbols/2.2.0",
+    "dest-filename": "analysis-kotlin-symbols-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/analysis-markdown/2.2.0/analysis-markdown-2.2.0.jar",
+    "sha512": "3370ad3e79534a66889e3862b2de2aff071661dfece1a98a723740e3083b030592194f7db35af8202ca14bec87ff2eddc08696434d4c9e69a6f9876eabfb7d5c",
+    "dest": "offline-repository/org/jetbrains/dokka/analysis-markdown/2.2.0",
+    "dest-filename": "analysis-markdown-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/analysis-markdown/2.2.0/analysis-markdown-2.2.0.module",
+    "sha512": "2b0e8d0b7c274de76ff2a8f86d1b77a3a99f8fa088f23bf32617022e29ad60daecc38e9398efaba98e0db1910ca584cb909ac6eb33857e595dd75d08d9d4f581",
+    "dest": "offline-repository/org/jetbrains/dokka/analysis-markdown/2.2.0",
+    "dest-filename": "analysis-markdown-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/analysis-markdown/2.2.0/analysis-markdown-2.2.0.pom",
+    "sha512": "c027d6661fa9153c2f527013cfae18f8fd66f8ba3479fcce79912240138e16a6582e711d5176c65b52d9f6d8a9dcb1115c300894214ed689f8a7e50908587c5b",
+    "dest": "offline-repository/org/jetbrains/dokka/analysis-markdown/2.2.0",
+    "dest-filename": "analysis-markdown-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-base/2.2.0/dokka-base-2.2.0.jar",
+    "sha512": "f33da2cb2a693bc95da696143c15775977f8682da14a9a6c4f83ac147ac3fe4dcaa0f5679dbbdecb41781d9d4b341254024744e302a91d6679201f220b4a66fa",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-base/2.2.0",
+    "dest-filename": "dokka-base-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-base/2.2.0/dokka-base-2.2.0.module",
+    "sha512": "49ffda6e8eda918717e684d873be0c7b8e06f9d7f847c4f130d26ed30044dfd23d3f849d551f9e8c1f4592944ab1e8b3ecadc3d4f0f318f22f02db314146ea4a",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-base/2.2.0",
+    "dest-filename": "dokka-base-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-base/2.2.0/dokka-base-2.2.0.pom",
+    "sha512": "3faa879d88bf77d5828f50fdecdc69331e404f34c90be7a1050b3ff07eca4d6d8d5b0997ecf7361f43d0e34e0672be5e4da06149cda70bada1bbe4fef64367f9",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-base/2.2.0",
+    "dest-filename": "dokka-base-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-core/2.2.0/dokka-core-2.2.0.jar",
+    "sha512": "52ca04c0c6d2ba9011cbe101c2e0eb316bb47b4d0945fad54db6d412dece74f349022511c90d3a9b0ee3f4c9169ce947dde0083b0751df9104a49bbaf1d49645",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-core/2.2.0",
+    "dest-filename": "dokka-core-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-core/2.2.0/dokka-core-2.2.0.module",
+    "sha512": "96ebaa1917a780520f00b5ee70a92d5884a429c2869178d893f377443db56ce3cc6db03063533a4751291a46f75b8d093d2dcacd04ec92e8cb2c56f72fd564b0",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-core/2.2.0",
+    "dest-filename": "dokka-core-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-core/2.2.0/dokka-core-2.2.0.pom",
+    "sha512": "3c909292556f23db69678b472c5bf20ed0e673a96831ad2f19b90da7f9777063d020e59f6a63ed2684f263cc3ca597c51c875085eb987d6bd67d0ee137bf3909",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-core/2.2.0",
+    "dest-filename": "dokka-core-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-gradle-plugin/2.2.0/dokka-gradle-plugin-2.2.0.jar",
+    "sha512": "bf063b03fa80c000a33f2bef8c39eff4751412a013bd8e41d7af773f7776cfe8f1ab98918d5eb5a00e7303325eb3c27e108f2a8923f1a0fe230f7297bb0ebae0",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-gradle-plugin/2.2.0",
+    "dest-filename": "dokka-gradle-plugin-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-gradle-plugin/2.2.0/dokka-gradle-plugin-2.2.0.module",
+    "sha512": "e53c1522008688d33c08c1752160e42a0b3020478bc7cfed6936b126e8268fe6a042e5b2a45317e343e6df1d60eccc97cfa1a6b9f3ea625ceac57382bdd5f515",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-gradle-plugin/2.2.0",
+    "dest-filename": "dokka-gradle-plugin-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/dokka-gradle-plugin/2.2.0/dokka-gradle-plugin-2.2.0.pom",
+    "sha512": "254d88f9a69bf61fc39f5c73e3a34138987fc2f30ed452d5f2f121c57d0906ef82cee37b8e098b52751426b8bd12361fc1e0a53cace2b741b6ff0d410f4eba05",
+    "dest": "offline-repository/org/jetbrains/dokka/dokka-gradle-plugin/2.2.0",
+    "dest-filename": "dokka-gradle-plugin-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/org.jetbrains.dokka.gradle.plugin/2.2.0/org.jetbrains.dokka.gradle.plugin-2.2.0.pom",
+    "sha512": "db33edd2635474a47d775fb8d2af98d3fcad2bcabf541c4557d8c3b3c08b395f34c9c07110aabbae9c4a7d5c203ec64c5585ee29c45afa07ebeaa5d0594b0cd0",
+    "dest": "offline-repository/org/jetbrains/dokka/org.jetbrains.dokka.gradle.plugin/2.2.0",
+    "dest-filename": "org.jetbrains.dokka.gradle.plugin-2.2.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/templating-plugin/2.2.0/templating-plugin-2.2.0.jar",
+    "sha512": "bbdf75702bf1765e8490306e41fcd194dcd38a5690333cb729f6b77b3730475367980db07331c7184e95bb7dc498a27fe337076575064f3786656458a1f7b9e0",
+    "dest": "offline-repository/org/jetbrains/dokka/templating-plugin/2.2.0",
+    "dest-filename": "templating-plugin-2.2.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/templating-plugin/2.2.0/templating-plugin-2.2.0.module",
+    "sha512": "ab5a22d3ead7feefdad444d1e0502150a1b6a0633b0405b7a1ed0fba2f7410efa4cb0d5f1bda6ef2f93bd2f4477f931852823e7f898adb6944354f8ed14c8fe5",
+    "dest": "offline-repository/org/jetbrains/dokka/templating-plugin/2.2.0",
+    "dest-filename": "templating-plugin-2.2.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/dokka/templating-plugin/2.2.0/templating-plugin-2.2.0.pom",
+    "sha512": "12a44c4869611070bf4c958cb115268b8b1e137b922afe1d9ac70f921983dad82fecca9b41366ee2babfcaf6b8c0b2dd0c0afe17bad0aaa087cb16fd04f7b020",
+    "dest": "offline-repository/org/jetbrains/dokka/templating-plugin/2.2.0",
+    "dest-filename": "templating-plugin-2.2.0.pom"
   },
   {
     "type": "file",
@@ -1464,6 +2185,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar",
+    "sha512": "3b35fb5684bc7cad47a5c068b2671ae55cabe6ca16745277ac44ce0785b1384ad35444fbe10b68ca7c360ba9a86b0061a6101956b370e6c19bd8c85c9bc13dcd",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.0.21",
+    "dest-filename": "kotlin-reflect-2.0.21.jar"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.pom",
     "sha512": "39be2e959d5c2e2e22445edcfb41b43497b2ad5edfc936081a6a72fcf8b9291571f5d3d6a7ef5d7eb30ddd2cff744966f68ddfea2da33120bf30326e12492425",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.0.21",
@@ -1660,10 +2388,24 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.0.21/kotlin-stdlib-common-2.0.21.module",
+    "sha512": "ad4142f6d86b2daffae8dad0289de4a9d369ec72948b365081a0ebd6841556ac2fe6e5b199edd1a9c4db104905c524129e09aefa67dc2790b476d025700eba3b",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.0.21",
+    "dest-filename": "kotlin-stdlib-common-2.0.21.module"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.0.21/kotlin-stdlib-common-2.0.21.pom",
     "sha512": "85a2f145f964d2296694ba5ab03f116268267fcca5eaf1f63445b5bfb3478997057d57f8e60661979e7aa55fc028728ac3aa7a385a4ef7109e904f104c59308e",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.0.21",
     "dest-filename": "kotlin-stdlib-common-2.0.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.21/kotlin-stdlib-common-2.2.21.module",
+    "sha512": "54943241172e99f70903e3f71a2167237a0851418b0c0afc3e86803516923b9469799f9f7cc5de7be9a595b620398103724fc9c0ee8d65cc4823b990eacbfdbd",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.21",
+    "dest-filename": "kotlin-stdlib-common-2.2.21.module"
   },
   {
     "type": "file",
@@ -1702,6 +2444,20 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.20/kotlin-stdlib-jdk7-1.8.20.jar",
+    "sha512": "ebc0c62f46206e55c18aa9343863dc79590a7f68f487e48b5241e53281b7441ac3653fa73ec47a8b383898986e6ff7ed042f55269a0fb2e7b337aac0ea727df1",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.20",
+    "dest-filename": "kotlin-stdlib-jdk7-1.8.20.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.20/kotlin-stdlib-jdk7-1.8.20.pom",
+    "sha512": "aff8a9d79864225c810dac54b186d89870a31aed43d33303930ade19c93b9818a2d5a667d5f1e9ea6d9b55addb8bd9f0a889f1610733d3c522bc08acef590ecd",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.8.20",
+    "dest-filename": "kotlin-stdlib-jdk7-1.8.20.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21/kotlin-stdlib-jdk7-2.0.21.jar",
     "sha512": "6d79df42475c37e332c06da5ffa870589a04e676cd99c292500d10ebc4556d36659440157eb6d88dc813df12126826db7722fd3667f23463011dd284b89fe2d8",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.0.21",
@@ -1737,6 +2493,20 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.20/kotlin-stdlib-jdk8-1.8.20.jar",
+    "sha512": "1d7d01280ba9461c2e55a54cbb5c36f2c31949cba85eb69dae461d9136e2a8640b9ba5326604ace23b1bc311d54158199ec56ea90ccddb7fe03e1f4348750738",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.20",
+    "dest-filename": "kotlin-stdlib-jdk8-1.8.20.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.20/kotlin-stdlib-jdk8-1.8.20.pom",
+    "sha512": "d231849c512fb85fdf837d9da762ff8e8e0207ff6e4c0eda344d3a551444d8615305b35255ecaebb0fb1bd546f97f75ffb06b85635f77d9c82b464af107c02a4",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.8.20",
+    "dest-filename": "kotlin-stdlib-jdk8-1.8.20.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21/kotlin-stdlib-jdk8-2.0.21.jar",
     "sha512": "8ca85069e6f90da6fe2942e0162676c16c9b45cfa4da7a26b9811e4f1f89c7b859416dc8353c58819c6726ba463546ad7720a859a325a106f4bc606c57f67ee9",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.0.21",
@@ -1769,6 +2539,20 @@
     "sha512": "010d92e4558304d66934d4d717ff0eee06a1b5ba138fa6a7e1dd754a4cc2a050cd91abb238ca7117578402138cbad3a5f10f16ad4b4ad3eaf81c695562a907f6",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-js/2.0.21",
     "dest-filename": "kotlin-stdlib-js-2.0.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar",
+    "sha512": "4e6786c4e7af13eddc5a2a06b336f430987f16ac1f4c0af541cd97400d689f7d8726a276ca549e7f19d7b939f47a1535dff7ea45f76b14197a0e876cc44d3acd",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.0.21",
+    "dest-filename": "kotlin-stdlib-2.0.21.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.module",
+    "sha512": "28d2618070b9a596ed01a547f360d21bee2d504020952cda8b8a914ee05454b6560eacb4d4d602ae61b915559e76acbb3bcc96b25fe76140ec14cca5d8c07261",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.0.21",
+    "dest-filename": "kotlin-stdlib-2.0.21.module"
   },
   {
     "type": "file",
@@ -1933,6 +2717,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.7.3/kotlinx-coroutines-android-1.7.3.pom",
+    "sha512": "3c309f5471e5980f4a5c738b4d107ba4ee45456e3018d84cabe4d234c50db52a7ff76d4810a43e5bd31122bae863e634925354f97803860e3dbb79c45a5674c7",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.7.3",
+    "dest-filename": "kotlinx-coroutines-android-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.8.0/kotlinx-coroutines-android-1.8.0.pom",
     "sha512": "9f10dcfcf35c2c4844f0ef88584e543baf4fea165d73ec387c2bab58e1c64966458358970a699f0b0334e671cf97f0ff6e571df071477ae33c88e00b9271361a",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.8.0",
@@ -1944,6 +2735,13 @@
     "sha512": "019fd13ac4ed6829a32489afe003762936937d6894f16ac36f611beb2ef7e9fbb282e56479863da8daa156aa77f834c30420604e431b6e2e56311e3e0240b606",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2",
     "dest-filename": "kotlinx-coroutines-bom-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.7.3/kotlinx-coroutines-bom-1.7.3.pom",
+    "sha512": "149075f47e34f8e923b535380c97f6cf12cbd05ab6ddeaaafcb12e5d0117d48a1da1eebb491b21fbd1d6ad9e7b8aea8dbfd55d8aa22e6b4c31634d1a40b23646",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.7.3",
+    "dest-filename": "kotlinx-coroutines-bom-1.7.3.pom"
   },
   {
     "type": "file",
@@ -1972,6 +2770,27 @@
     "sha512": "e146303a289ff4ca6e6b93470d37036816a4a77c6d72f7fe8200befe3ba9317dad18e6aa6ee216403a163146b3cc3f55e9a53beec582029fb734d363255f1522",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
     "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.7.3/kotlinx-coroutines-core-jvm-1.7.3.jar",
+    "sha512": "67dda323e636329bd3db66fa0e60397b153ae1579465c7f39677b663cc1cd2ee6a1a84b29de86b8bc491958719d18da2adb1c6eb6662fb72e66619b58d5705fd",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.7.3",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.7.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.7.3/kotlinx-coroutines-core-jvm-1.7.3.module",
+    "sha512": "04533d7a72850ccb1219e57e4160bee87233c5f79241e1179c46db973e88f0dbbb5f3444538e4a53c361d51dada64f4ffcf1b66bb151ff8260590316c607a751",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.7.3",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.7.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.7.3/kotlinx-coroutines-core-jvm-1.7.3.pom",
+    "sha512": "0dc1f96c8bcfa67397288be7aba91ade9d5eaa444219f9ebffdb2a21694d596169dacc3df74e444b8f8ad084ffd42e8f71a4d6f671727fdc6de4be69da49d359",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.7.3",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2017,6 +2836,27 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.7.3/../../kotlinx-coroutines-core-jvm/1.7.3/kotlinx-coroutines-core-jvm-1.7.3.module",
+    "sha512": "04533d7a72850ccb1219e57e4160bee87233c5f79241e1179c46db973e88f0dbbb5f3444538e4a53c361d51dada64f4ffcf1b66bb151ff8260590316c607a751",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.7.3/../../kotlinx-coroutines-core-jvm/1.7.3",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.7.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.7.3/kotlinx-coroutines-core-1.7.3.module",
+    "sha512": "1f8ff194c7b54b60c733480762abfde32171cf11f6d8805ac12f6dd7f2f5726a297ffae851763bc5fa14ce333658d853e941f386ecddf796c31b47c6b733ae97",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.7.3",
+    "dest-filename": "kotlinx-coroutines-core-1.7.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.7.3/kotlinx-coroutines-core-1.7.3.pom",
+    "sha512": "2c69a51907543fe64c1e25092e2dbcd9007eefd39d78ed751c186f302cd5b66277db9f319f82e341d960ce339cc5a8a8d6a8857102c4df09fb9ef8e041a2bf76",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.7.3",
+    "dest-filename": "kotlinx-coroutines-core-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0/kotlinx-coroutines-core-1.8.0.pom",
     "sha512": "c9b309dcb8aee156210fff58c9fa01b74d186c78e5a6292d8fbbc42776f86cbe6a597e05ea2cd5759c3f93bdd2e4e4453f95dbf61abf994591c114e5cec61b9b",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0",
@@ -2028,6 +2868,13 @@
     "sha512": "62e88aa9c8399cb1550d8ffe6830768f00562383b0d8074c733945acd89ea1aed8664186a49a872ea521623a94183da217a2d0aa9a34d322f1cabf2464c20c13",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2",
     "dest-filename": "kotlinx-coroutines-debug-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.7.3/kotlinx-coroutines-debug-1.7.3.pom",
+    "sha512": "c98babe63a064dbab1aa8d82113de47ad46ceb0e9ebaf0c2767c92575c03a3608b6d924f463d6ab98794abf70e47e5d02248151ac48490cffd3603caa940ce64",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.7.3",
+    "dest-filename": "kotlinx-coroutines-debug-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2045,6 +2892,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.7.3/kotlinx-coroutines-guava-1.7.3.pom",
+    "sha512": "1b15b0bd56425a28d5bb6069ed84f3b4fcad0792641ffc7ba5b2fe105809b4c10a3720b873e924f8cc2cd8712c80506ab420082f3b47b83521097296613e7d79",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.7.3",
+    "dest-filename": "kotlinx-coroutines-guava-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.8.0/kotlinx-coroutines-guava-1.8.0.pom",
     "sha512": "4d08ac866aead40123ef4804c958a06ec52bdc5af64ee2524d81a8c65d3cad6f9605854d79449a6e52e644b4217c6f750b6f474c8311e39a1034d985829b46cf",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.8.0",
@@ -2056,6 +2910,13 @@
     "sha512": "38dc16d847a1579c67781b50be82395eccec98ea02eb25b434457819259a3fd98d7a10cf29a40f4b2a49e77f10dea49acccf888c9950ce9dc8ee9dbfb0ce8620",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2",
     "dest-filename": "kotlinx-coroutines-javafx-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.7.3/kotlinx-coroutines-javafx-1.7.3.pom",
+    "sha512": "6c7f31ff41ded47be2e609e05af2a81c981fa197f70f5e1773368bcc568aa54234583fe675bf8f71ec68964d54f54495e1547ae08baf6dc0676e67fa5ff24ebc",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.7.3",
+    "dest-filename": "kotlinx-coroutines-javafx-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2073,6 +2934,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.7.3/kotlinx-coroutines-jdk8-1.7.3.pom",
+    "sha512": "23849a5a6b407bf8bc5adf097a06942f2fc0e0b44bc3140b23a47602f0ce8ace5c6d0ad01108385f8807793f1b50390b79b65cd3c9963caca90cfd6a1bf52c25",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.7.3",
+    "dest-filename": "kotlinx-coroutines-jdk8-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.8.0/kotlinx-coroutines-jdk8-1.8.0.pom",
     "sha512": "86a60743fce1550331948226814887846ebd855091a40dae69e272c0c5492fb3218fa6f1f7fa4c47e3099f4edf1de064ee708273c24e971cf1c0e1f1f9d90295",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.8.0",
@@ -2084,6 +2952,13 @@
     "sha512": "1d6dd9c33bd42d8170bc2196346ef84445f74ce11b47730b6194a1c5ec1e066fcfcf2ff11c071f24cc53476d917ab04773c7e478c054d26fac159ca4c3ce7230",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2",
     "dest-filename": "kotlinx-coroutines-jdk9-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.7.3/kotlinx-coroutines-jdk9-1.7.3.pom",
+    "sha512": "11a97d03f2bd466ab3020409c048dde8c78fe1c63930f8471c312ce6ce2d0859d788c74a2b9765c47c342da403c8aa7a0438bd9d901f7c617e8cdd3ad630b6e4",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.7.3",
+    "dest-filename": "kotlinx-coroutines-jdk9-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2101,6 +2976,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.7.3/kotlinx-coroutines-play-services-1.7.3.pom",
+    "sha512": "39562ed6ad0b7b7b26dc9b91248a48b54627fdc54008c9a8237232a91e1bcbba5e30e29c813823f957e534d1e5e656b2ec17f4c95b8d043cf84d9da623e3d1a2",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.7.3",
+    "dest-filename": "kotlinx-coroutines-play-services-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.8.0/kotlinx-coroutines-play-services-1.8.0.pom",
     "sha512": "ff0a43339cc1e7b6359476afc2865a5a071c69564302f7d60497ef1585296c7412bdf4ea5c8d7be2691eddb7d78e577487760f94b6823baf09d661fbd629fef9",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.8.0",
@@ -2112,6 +2994,13 @@
     "sha512": "9ba65dfa502929f8916f57894b8ea6205bb52a44eb8aaa5cea0c5630837ce476747e4af8d72ac9df6cabbab8f34398106f825be985600c37fb77e79a9552d17a",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2",
     "dest-filename": "kotlinx-coroutines-reactive-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.7.3/kotlinx-coroutines-reactive-1.7.3.pom",
+    "sha512": "c4c6ae535440dd3146e439a2eb699511d41779742dc97510a699087912fe9588454100e1364656770ef1a042e0bbb421d70073fcd55be688ca5a5deedb0593a7",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.7.3",
+    "dest-filename": "kotlinx-coroutines-reactive-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2129,6 +3018,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.7.3/kotlinx-coroutines-reactor-1.7.3.pom",
+    "sha512": "ec396d5012f5ae9c4f407329ecf3a6e50eb31febf0ab35d6b377d082a74046dc112b71d6d46be3e37df26ae1ccdd01d39d22f180f6747bc250c013fa6c9785f9",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.7.3",
+    "dest-filename": "kotlinx-coroutines-reactor-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.8.0/kotlinx-coroutines-reactor-1.8.0.pom",
     "sha512": "72f18d5ca890a927d3e6ea4b0b51c9e8b7db8c74904a1b530743a22cb12a74d42dbe51c8a305f875357c1dc48ac67ecc1df78ffa0359354bfd0b8c0b473ba340",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.8.0",
@@ -2140,6 +3036,13 @@
     "sha512": "19966b5d3355093806434a106588b8d988a23688e602ae9200a0dda5f159e04856049815509f5b7ab9bfeeb1929c700f0a9bc9b8f0848a27fdc19211e5dee711",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2",
     "dest-filename": "kotlinx-coroutines-rx2-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.7.3/kotlinx-coroutines-rx2-1.7.3.pom",
+    "sha512": "ae0c9d23ddcdc99530d2e4994708406410d9893d898282b91cc319f36564756316ca063d79d89df49d2e13a99b80d0c8b0840c143986776828d4e75d5ce0fe8c",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.7.3",
+    "dest-filename": "kotlinx-coroutines-rx2-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2157,6 +3060,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.7.3/kotlinx-coroutines-rx3-1.7.3.pom",
+    "sha512": "756ad9d495275a3a6522e1279dfc175b7da27c6dee9a7e9ef48153be5a19a3a5845614faaa8a9755c56313e295b6d1e77772511fc0870e8c3cd41001c6af9bfa",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.7.3",
+    "dest-filename": "kotlinx-coroutines-rx3-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.8.0/kotlinx-coroutines-rx3-1.8.0.pom",
     "sha512": "7c41defe6cfe67e8ed6330be15553e641a75dada600b98c96fb1096cd3f484228d7c3034b523f13d0fa74e31a7bf5bd0dafc30080b176d898da69a93907d66fd",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.8.0",
@@ -2168,6 +3078,13 @@
     "sha512": "e3aeda087f93866da540b152573520706daa7bd3f0cc46a18249f27cf35c17fa74f22203716e1f2ff91c7722fc9617bf7c8a1ce8a72992855ad52940be61bf30",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
     "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.7.3/kotlinx-coroutines-slf4j-1.7.3.pom",
+    "sha512": "0d7a6319e31fb95412b6e91b222982c46d1153155466e98790c56e0289514035daab6bc37c5cfec0870dcff986e954a56bb6227d079b919a10de97f0725b6479",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.7.3",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2185,6 +3102,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.7.3/kotlinx-coroutines-swing-1.7.3.pom",
+    "sha512": "cff3f1f05d53655c37d62e46ae2c06b568a74076380d2b8110c8acc49b92ae81902d31b6327a166c1a38267956c0c6c6f1886886ad0d0dea37b896ddc4ed9e25",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.7.3",
+    "dest-filename": "kotlinx-coroutines-swing-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.8.0/kotlinx-coroutines-swing-1.8.0.pom",
     "sha512": "9615b57fcc82c87978371a03626f4d064ded28d2e7575db5f3e78bc31373da23fe86f0512fe9da29229591660e644d50886fe1307a8b684edc26d3790acdc548",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.8.0",
@@ -2199,6 +3123,13 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.7.3/kotlinx-coroutines-test-jvm-1.7.3.pom",
+    "sha512": "892cef60dfcdf7567eb549185acae8ecee5abbfcb1c5ea226952691c53bec23168a9694829a4bda2e6093697429456bdb8f3041c19a97e17233eef0082d551f2",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.7.3",
+    "dest-filename": "kotlinx-coroutines-test-jvm-1.7.3.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.8.0/kotlinx-coroutines-test-jvm-1.8.0.pom",
     "sha512": "d9c8947372a8d88f3b92d83eedac01013dee9f364d66441ad26daf5961944a868ed99d02b491a9855521b7f2e2baae96c8d195837ce423128c0c596cc2733503",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.8.0",
@@ -2210,6 +3141,13 @@
     "sha512": "4d49f5a32e32558d490f6159be5740a361b2ed615f762a63623b430feca757d499934157e16c52669b07a14cbe5ffe42e192db26b81190b06e3b84963ddaaeed",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2",
     "dest-filename": "kotlinx-coroutines-test-1.10.2.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.7.3/kotlinx-coroutines-test-1.7.3.pom",
+    "sha512": "38e0f3781f802420e4790e6aa80b18a29b6160472a48cb3f31c658bc0f78dddd1edf86c44e582b735d662da318172c005a77b6d66bf0d6fb8e830d1501f56b60",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.7.3",
+    "dest-filename": "kotlinx-coroutines-test-1.7.3.pom"
   },
   {
     "type": "file",
@@ -2283,10 +3221,38 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.jar",
+    "sha512": "5584621c56ded6989641fad868bb4b6a8cae20fa9d274dc6c32c825c6f78c8fcf769cd259559dfcbee6ca5703597c7a8e2c7fabe56c406072ff35f53af87ff86",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1",
+    "dest-filename": "kotlinx-html-jvm-0.9.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.module",
+    "sha512": "15afb7f038ae54171862ba7942c8ac187a224587555141698d79e288b4e24b8d611056567bbb0877802d47d4b977c1c6d68d40e80f1f85d95c6a23bab7fd385d",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1",
+    "dest-filename": "kotlinx-html-jvm-0.9.1.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.pom",
+    "sha512": "88196cf0a8cd04a12f153b3070ab1e522caa23fc24b3d93e18aea58c166d76581dad32a4ae0ec66ab57db5343bfe775362398ac0284e39e12b4a8170d6dfcebb",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1",
+    "dest-filename": "kotlinx-html-jvm-0.9.1.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.10.0/kotlinx-serialization-bom-1.10.0.pom",
     "sha512": "fd2506eae3e81484e49f6e175387e12f81c58f00784e00d1f5dc771c7d5e351b737570e4a1b976eb6565ca3a9dedce37eac68513bb46a2f49c8242da4ac73fd8",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.10.0",
     "dest-filename": "kotlinx-serialization-bom-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.6.0/kotlinx-serialization-bom-1.6.0.pom",
+    "sha512": "fafab56b7676d6f223e3b8452c2cc04b93461169724b16084fc26b5bc6983a62563f6d645fed3f7ebbf23779dc79b855028b5ffa0e29ebb36c57ccfe4ba7e1c2",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.6.0",
+    "dest-filename": "kotlinx-serialization-bom-1.6.0.pom"
   },
   {
     "type": "file",
@@ -2297,10 +3263,24 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.6.0/kotlinx-serialization-cbor-jvm-1.6.0.pom",
+    "sha512": "6b06870ef274acd90d37f5785ca02f7977dc7a5d1f5c493d2ff1f0702b9fab840c8e4359e40e4296b56a7d47102b8907e7b54760318557860fc97b1cecbf9b8b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-cbor-jvm-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.10.0/kotlinx-serialization-cbor-1.10.0.pom",
     "sha512": "1fd0c8dfdb847d04adb209f1fb0ba2909d2f76f2a3b06b556a5892e15e25ec50abb55556cebf35954b1b11d8fe2db111c55e127bdf79ec6c7ad02a368023156d",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.10.0",
     "dest-filename": "kotlinx-serialization-cbor-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.6.0/kotlinx-serialization-cbor-1.6.0.pom",
+    "sha512": "2fe25bc9b32aba6dca4f79b512503872c2c9b4bc2e1b99cefc604f2e1429714cdd500dd9d7dea0ff36dda1eb8855be1a46514033a7dd00f40ff1f6babb283b7b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.6.0",
+    "dest-filename": "kotlinx-serialization-cbor-1.6.0.pom"
   },
   {
     "type": "file",
@@ -2346,6 +3326,27 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.6.0/kotlinx-serialization-core-jvm-1.6.0.jar",
+    "sha512": "00acbea5ea23eef514f410487466c5a13a08c0fd05cedf22a980a788184d95bc8033bb845c75f54a92dd6d104560e7b4c0141b092521349fea072f1bd89f6470",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.6.0/kotlinx-serialization-core-jvm-1.6.0.module",
+    "sha512": "f42a2d7d1f6e9ff9993ca0629abd12b571ff34d2fe3cf2429b1abea94a86c23ab7a6b23892491d70556f9a07b7e1128a8deecd970ab44361e4c61c90273bfd4f",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.6.0/kotlinx-serialization-core-jvm-1.6.0.pom",
+    "sha512": "96e96b69fe88ef2e300aff1a095dd1cf77c8ff7462ec52284b2e5f178171bdd94c50faa0187bce53757c85def1e4ba66bb5142757d041b61cd146f7067ed26a4",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/../../kotlinx-serialization-core-jvm/1.10.0/kotlinx-serialization-core-jvm-1.10.0.module",
     "sha512": "19bb80223874dba5cf3899367d6eca4b351c6acf8a1bce54c9c58a53822f9d4b523ad6e6c74771f276529a2169a8d69ff83d9a66e70999ef89daef401193e095",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.10.0/../../kotlinx-serialization-core-jvm/1.10.0",
@@ -2388,10 +3389,38 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.6.0/../../kotlinx-serialization-core-jvm/1.6.0/kotlinx-serialization-core-jvm-1.6.0.module",
+    "sha512": "f42a2d7d1f6e9ff9993ca0629abd12b571ff34d2fe3cf2429b1abea94a86c23ab7a6b23892491d70556f9a07b7e1128a8deecd970ab44361e4c61c90273bfd4f",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.6.0/../../kotlinx-serialization-core-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.6.0/kotlinx-serialization-core-1.6.0.module",
+    "sha512": "8af0358cd2d6643afd43fac227ad0773c3dfdb4bbada2312b2ea4c6b8a3527d53fa79dfd35965785e73c17201039759814d9aee85c30330ee9843dae0ec0caed",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.6.0",
+    "dest-filename": "kotlinx-serialization-core-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.6.0/kotlinx-serialization-core-1.6.0.pom",
+    "sha512": "ff708bb478df32bfbddacb67019e64d265ab6550d5888f9eaaeabb2c2a10ecf961da59aad613e043ed3108e51f544296065cc8f95330a2b26d3b9d21504dcc08",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.6.0",
+    "dest-filename": "kotlinx-serialization-core-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.10.0/kotlinx-serialization-hocon-1.10.0.pom",
     "sha512": "5230c7bd01df301df799355ecdf4aee783d4396a4229d50d7b35d3b96b28c28e4a264a09d0b647b18345f992c65457543647c68f6fa68ddedb7c0282bfe409e7",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.10.0",
     "dest-filename": "kotlinx-serialization-hocon-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.6.0/kotlinx-serialization-hocon-1.6.0.pom",
+    "sha512": "1a401b85ae8e8519a20b9e626b9225819db9744a1e8d3ed4b80030c4fa38a78ef89986a9c36462302785b563efa87439b61f23bd599a1486eb38526b7a1fdbbb",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.6.0",
+    "dest-filename": "kotlinx-serialization-hocon-1.6.0.pom"
   },
   {
     "type": "file",
@@ -2451,6 +3480,27 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.6.0/kotlinx-serialization-json-jvm-1.6.0.jar",
+    "sha512": "274463ea8d3d94f21b31366711ff614092ace74c347ce083b17ada2ffd16c1dddd47710ba843a36d0518efceb1083f507d2ac1408186cb3994380b63f48a529e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.6.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.6.0/kotlinx-serialization-json-jvm-1.6.0.module",
+    "sha512": "27889404156b9b59662674367e57a0ecff5968b50034d8eecb41150f6d78f48f73a6af0c2a44a5ed0f520d1fe933c1297bdb45e7d0abe977c2ef925786e83289",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.6.0/kotlinx-serialization-json-jvm-1.6.0.pom",
+    "sha512": "1548d49b54dc0b047b21929ce364023d7b08ab2c38f36c49aa746ec5c5e5b403986cda0e780263897ccd1e9a9932f75581d3da3150e1f72ede761eb67c89804b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.10.0/kotlinx-serialization-json-okio-jvm-1.10.0.pom",
     "sha512": "b834816001eb6709a2edb22d69e12a2351ef348b061007a458062dd52471e8306d59424a68d3a64e2dba181678814f1f858bbdc5f5d6b1bafe7462ce19f59451",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.10.0",
@@ -2458,10 +3508,24 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.6.0/kotlinx-serialization-json-okio-jvm-1.6.0.pom",
+    "sha512": "f336f10b5424ca98b471f0834fb88bf6fff460f42e9a866fffef24fac34e8760a0b6c2797a71abc8c85c92c76d910073382e86b46451bcfe99fa6cfdc5e87b3e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-okio-jvm-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.10.0/kotlinx-serialization-json-okio-1.10.0.pom",
     "sha512": "acba739a7c00556bfdeefc941640f06f495cd06e3dd3ee50f1422213388d0af7174b35d54666fc6577b0a9823854b51f5ef365341029fd1e6901d32eb52e2236",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.10.0",
     "dest-filename": "kotlinx-serialization-json-okio-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.6.0/kotlinx-serialization-json-okio-1.6.0.pom",
+    "sha512": "7aa3df8190f9cca02c034d5a9739cc65bcd6e79085358d82aefee1f79699eb02c8277c12091b6997c55ed642735aa557d48e927eb70f06499d760e6a47dc1c88",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-okio-1.6.0.pom"
   },
   {
     "type": "file",
@@ -2507,10 +3571,38 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.6.0/../../kotlinx-serialization-json-jvm/1.6.0/kotlinx-serialization-json-jvm-1.6.0.module",
+    "sha512": "27889404156b9b59662674367e57a0ecff5968b50034d8eecb41150f6d78f48f73a6af0c2a44a5ed0f520d1fe933c1297bdb45e7d0abe977c2ef925786e83289",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.6.0/../../kotlinx-serialization-json-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.6.0/kotlinx-serialization-json-1.6.0.module",
+    "sha512": "a480f087f066d94e5283ff8aff275deba9cd99bac55a86d8e33060d2662e940fb0db924ea05282b7b4ab2c6dd5b62c21ce11d1307a85ce07ab30ae80760a9513",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-1.6.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.6.0/kotlinx-serialization-json-1.6.0.pom",
+    "sha512": "849e6128a51345d69e4f71edcea1353183faf996a211a98f3de4ec524dda2dc064ebf08ecbfb82270e63eed392ed4c63e4c338eba52448169b37a005dbd1c68b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.6.0",
+    "dest-filename": "kotlinx-serialization-json-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.10.0/kotlinx-serialization-properties-jvm-1.10.0.pom",
     "sha512": "7018d746600988c2d80f8d55820218524810466f4918da4cbf89a9421fbf112cc638a11e4b768a4d8febb23f278ad05200b1353304b42d736924674615233524",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.10.0",
     "dest-filename": "kotlinx-serialization-properties-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.6.0/kotlinx-serialization-properties-jvm-1.6.0.pom",
+    "sha512": "27408220c48dbf30df42448af6899591279500cae2c2b979ac36973013f4205c67e68aa5305276e38e9046628add99a8c459dd00614d06ff71618a5faea05e6b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-properties-jvm-1.6.0.pom"
   },
   {
     "type": "file",
@@ -2521,10 +3613,24 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.6.0/kotlinx-serialization-properties-1.6.0.pom",
+    "sha512": "0e49f7bace116baf66a5d8931a6d77aa2c929700504ec3ba511e371044267caa812adaed8b1b7738f8b23f10fd5f23f57b2fac932fbd3a6eac85511065535b10",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.6.0",
+    "dest-filename": "kotlinx-serialization-properties-1.6.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.10.0/kotlinx-serialization-protobuf-jvm-1.10.0.pom",
     "sha512": "25253b58b0c94329e805f7294912d5da5420a117f011a995b9c0ff2a0b999b38452f02546c6352570147559ca4790983b9b5605950a955a6be520c457d135727",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.10.0",
     "dest-filename": "kotlinx-serialization-protobuf-jvm-1.10.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.6.0/kotlinx-serialization-protobuf-jvm-1.6.0.pom",
+    "sha512": "85ff8e9a07fdd87b17718d34b6ba9eb6b9910fe3b350b8c634dc9d84f305fd7dd58cc6d7c5e33dfffaed44b433af059c4a6ef495d85b35bb94ccdcce64dd2a9c",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.6.0",
+    "dest-filename": "kotlinx-serialization-protobuf-jvm-1.6.0.pom"
   },
   {
     "type": "file",
@@ -2535,10 +3641,80 @@
   },
   {
     "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.6.0/kotlinx-serialization-protobuf-1.6.0.pom",
+    "sha512": "641469c1a66ff1bca326c18f98a4341b8b10e1ad97db0e0a6407bbb302e713e876a539be03e69b8dc3112f2dd511240a007182b8f17a9e9830e4e68c32d1f632",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.6.0",
+    "dest-filename": "kotlinx-serialization-protobuf-1.6.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/markdown-jvm/0.7.3/markdown-jvm-0.7.3.jar",
+    "sha512": "d74abb9ebc518f6d60d84df187390e82fa918ef805f887ea543d7ffd1a83393e80fc2fa2e0ca50e1ca7275e4a2c8652d2be01d763a771391c5d3fa0b4f8bea71",
+    "dest": "offline-repository/org/jetbrains/markdown-jvm/0.7.3",
+    "dest-filename": "markdown-jvm-0.7.3.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/markdown-jvm/0.7.3/markdown-jvm-0.7.3.module",
+    "sha512": "03fd8d6ae5d7dd08dc77669cc2a75a28a22aae1235721b77146d6201261693b336b29fa531606e4b1e30e28ad21f5d5f2581926f09e45e014847b4f0d7ad4ed4",
+    "dest": "offline-repository/org/jetbrains/markdown-jvm/0.7.3",
+    "dest-filename": "markdown-jvm-0.7.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/markdown-jvm/0.7.3/markdown-jvm-0.7.3.pom",
+    "sha512": "a5e6f36bf110013f8cf95f57e61fdd666c4f2bfc49c8edf064e78ce56093fb68e66226e3dc79c18fa83bfc504569e9e7cfe506e86ab3377fedb1eeb8690d3e2e",
+    "dest": "offline-repository/org/jetbrains/markdown-jvm/0.7.3",
+    "dest-filename": "markdown-jvm-0.7.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/markdown/0.7.3/../../markdown-jvm/0.7.3/markdown-jvm-0.7.3.module",
+    "sha512": "03fd8d6ae5d7dd08dc77669cc2a75a28a22aae1235721b77146d6201261693b336b29fa531606e4b1e30e28ad21f5d5f2581926f09e45e014847b4f0d7ad4ed4",
+    "dest": "offline-repository/org/jetbrains/markdown/0.7.3/../../markdown-jvm/0.7.3",
+    "dest-filename": "markdown-jvm-0.7.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/markdown/0.7.3/markdown-0.7.3.module",
+    "sha512": "dd5e775589ab113b65fe8256df4ac945b3e9885271d08b4aaad38c028d0c05daff2ab2c6c3ac7942d55c780caecce2b07253b92069f34b1afb3e842353c59f70",
+    "dest": "offline-repository/org/jetbrains/markdown/0.7.3",
+    "dest-filename": "markdown-0.7.3.module"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/markdown/0.7.3/markdown-0.7.3.pom",
+    "sha512": "0e6b72b6286d5a7810bb15d7ba3f86141c5c659db4701a43bc60171ffa04df81ec97b7672ec7e127e323f7114b2ea07e239c1a53d9fb6a3c335741df4468c473",
+    "dest": "offline-repository/org/jetbrains/markdown/0.7.3",
+    "dest-filename": "markdown-0.7.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jsoup/jsoup/1.16.1/jsoup-1.16.1.jar",
+    "sha512": "7361e52006735b7588b291067226e6be0128161bea01a11d6ef4425b5815f08cf36db9f52e3a7afcbaa322f510df4084bee1fdff379521ddd5d6d326d2b9f3c3",
+    "dest": "offline-repository/org/jsoup/jsoup/1.16.1",
+    "dest-filename": "jsoup-1.16.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/jsoup/jsoup/1.16.1/jsoup-1.16.1.pom",
+    "sha512": "41cbae7a77c78a9c06c1aa2d49e6fdf6a7c72e1064ad5d009d2960b2f08456d4b17a60e301c30bf6b8c3aa9f70d6c5d38337dfe16178c37ae7158a4f43b16f9f",
+    "dest": "offline-repository/org/jsoup/jsoup/1.16.1",
+    "dest-filename": "jsoup-1.16.1.pom"
+  },
+  {
+    "type": "file",
     "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
     "sha512": "ec795b2f32982c1af8dccef57553aa9d959c13ee829aebd6459ba22b4ef434aeb4184aa89f63ad2f0d8c45d59cd020a15cd976ddb4bf20f1044b492a406e029e",
     "dest": "offline-repository/org/junit/junit-bom/5.13.4",
     "dest-filename": "junit-bom-5.13.4.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://plugins.gradle.org/m2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom",
+    "sha512": "f7f727af2d3a0718f33f3e1a42eaeb645a1b7cb3401349111a6747aab3ef01b767b4d8cfc1b2c1449019207f2d63dc490a2e2632c60ca564ff85a81be00472f8",
+    "dest": "offline-repository/org/junit/junit-bom/5.9.2",
+    "dest-filename": "junit-bom-5.9.2.pom"
   },
   {
     "type": "file",

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenu.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenu.kt
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory
 /**
  * Server-side implementation of the com.canonical.dbusmenu interface.
  * Export this object at [DBUS_MENU_OBJECT_PATH] alongside the StatusNotifierItem,
- * and return [DBUS_MENU_OBJECT_PATH] from [getMenu] so the tray host can find it.
+ * and return [DBUS_MENU_OBJECT_PATH] from [StargateStatusNotifierItem.getMenu] so the tray host can find it.
  */
 class StargateMenu(
     private val items: List<StargateMenuItem>,

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenuItem.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StargateMenuItem.kt
@@ -11,9 +11,9 @@ sealed class StargateMenuItem {
 
     /**
      * A clickable menu entry with a text label.
-     * [onClick] is invoked on the D-Bus thread with a [tokenSupplier] that lazily consumes
-     * the pending XDG activation token. Call [tokenSupplier] from the GTK main thread
-     * (e.g. inside [org.gnome.glib.GLib.idleAdd]) to guarantee the token has been set by
+     * [onClick] is invoked on the D-Bus thread with a `tokenSupplier` that lazily consumes
+     * the pending XDG activation token. Call `tokenSupplier` from the GTK main thread
+     * (e.g. inside `GLib.idleAdd`) to guarantee the token has been set by
      * a concurrent [org.kde.StatusNotifierItem.ProvideXdgActivationToken] call.
      */
     data class Action(


### PR DESCRIPTION
## Summary
- Adds Dokka 2.2.0 to the `:sdk` module (plugin + version catalog entry) with module name and GitHub source links configured.
- Adds `make kdocs` target and a `KDocs` GitHub Actions workflow that builds and deploys `sdk/build/dokka/html` to GitHub Pages on every push to `main`.
- Fixes seven broken KDoc `[link]` references in `StargateMenu.kt` / `StargateMenuItem.kt` so Dokka generates without warnings.

## Manual follow-up required
Before the deploy job can succeed, enable Pages in the repo: **Settings → Pages → Build and deployment → Source: "GitHub Actions"**. Once set, the docs will publish to `https://zugaldia.github.io/stargate/`.

## Test plan
- [x] `./gradlew :sdk:dokkaGenerate` builds locally with no warnings
- [x] Verified HTML output at `sdk/build/dokka/html/index.html`
- [ ] Workflow runs green on merge to `main` (first run will require Pages being enabled)
- [ ] Published site renders at `https://zugaldia.github.io/stargate/`