### PR TITLE
Fix DBUS_MENU_OBJECT_PATH case to match AppArmor policy

### DIFF
--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StatusNotifierConstants.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/status/StatusNotifierConstants.kt
@@ -24,7 +24,7 @@ const val STATUS_NOTIFIER_ITEM_SERVICE_PREFIX = "org.kde.StatusNotifierItem"
 /**
  * D-Bus object path for the DBusMenu exported alongside a StatusNotifierItem.
  */
-const val DBUS_MENU_OBJECT_PATH = "/StatusNotifierItem/Menu"
+const val DBUS_MENU_OBJECT_PATH = "/StatusNotifierItem/menu"
 
 /**
  * com.canonical.dbusmenu protocol version implemented by this library.


### PR DESCRIPTION
## Summary

- Fixes `DBUS_MENU_OBJECT_PATH` from `/StatusNotifierItem/Menu` to `/StatusNotifierItem/menu` (lowercase `m`)
- The snap AppArmor profile on Ubuntu 25.10 only grants D-Bus send/receive on the lowercase path, so the context menu was blocked under confinement

## Test plan

- [ ] Build and run the app as a snap on Ubuntu 25.10
- [ ] Confirm the tray icon context menu opens correctly