### PR TITLE
Release v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the dependency to your project (requires JDK 25+):
 **Gradle (Kotlin DSL)**
 ```kotlin
 dependencies {
-    implementation("com.github.zugaldia:stargate:0.5.0")
+    implementation("com.github.zugaldia:stargate:0.5.1")
 }
 ```
 


### PR DESCRIPTION
## Summary

- Bump version in `README.md` from `0.5.0` to `0.5.1`
- Includes the fix from #41: correct `DBUS_MENU_OBJECT_PATH` casing to match AppArmor policy

## Test plan

- [ ] Merge into `main`
- [ ] Tag the merge commit: `git tag v0.5.1 && git push origin v0.5.1`
- [ ] Verify CI publishes to Maven Central and creates a GitHub Release