### PR TITLE
Add ScreenCast portal SDK implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Portal definitions are based on [XDG Desktop Portal](https://github.com/flatpak/
 | Realtime                  | ✅         | ❌          | ❌       |
 | Remote Desktop            | ✅         | ✅          | ✅       |
 | Request                   | ✅         | ❌          | ❌       |
-| ScreenCast                | ✅         | ❌          | ❌       |
+| ScreenCast                | ✅         | ✅          | ❌       |
 | Screenshot                | ✅         | ❌          | ❌       |
 | Secret                    | ✅         | ❌          | ❌       |
 | Session                   | ✅         | ❌          | ❌       |

--- a/app/src/main/kotlin/com/zugaldia/stargate/app/remotedesktop/RemoteDesktopViewModel.kt
+++ b/app/src/main/kotlin/com/zugaldia/stargate/app/remotedesktop/RemoteDesktopViewModel.kt
@@ -5,7 +5,7 @@ import com.zugaldia.stargate.app.textToKeySym
 import com.zugaldia.stargate.sdk.DesktopPortal
 import com.zugaldia.stargate.sdk.remotedesktop.DeviceType
 import com.zugaldia.stargate.sdk.remotedesktop.InputState
-import com.zugaldia.stargate.sdk.remotedesktop.PersistMode
+import com.zugaldia.stargate.sdk.PersistMode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/DesktopConstants.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/DesktopConstants.kt
@@ -1,5 +1,7 @@
 package com.zugaldia.stargate.sdk
 
+import org.freedesktop.dbus.types.Variant
+
 /**
  * D-Bus bus name for the desktop portal.
  */
@@ -26,3 +28,31 @@ const val OPTION_SESSION_HANDLE_TOKEN = "session_handle_token"
  * Result key for the session handle returned in responses.
  */
 const val RESULT_SESSION_HANDLE = "session_handle"
+
+/**
+ * Option key for types bitmask (device types, source types, etc.).
+ * Used in SelectDevices, SelectSources, and similar portal methods.
+ */
+const val OPTION_TYPES = "types"
+
+/**
+ * Option key for restore token.
+ * Used to restore a previous session.
+ */
+const val OPTION_RESTORE_TOKEN = "restore_token"
+
+/**
+ * Option key for persist mode.
+ * Controls how long permissions persist.
+ */
+const val OPTION_PERSIST_MODE = "persist_mode"
+
+/**
+ * Result key for restore token returned in Start response.
+ */
+const val RESULT_RESTORE_TOKEN = "restore_token"
+
+/**
+ * Empty D-Bus options map, reusable across portals.
+ */
+val EMPTY_OPTIONS = emptyMap<String, Variant<*>>()

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/DesktopPortal.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/DesktopPortal.kt
@@ -5,6 +5,7 @@ import com.zugaldia.stargate.sdk.notification.NotificationPortal
 import com.zugaldia.stargate.sdk.openuri.OpenUriPortal
 import com.zugaldia.stargate.sdk.registry.RegistryPortal
 import com.zugaldia.stargate.sdk.remotedesktop.RemoteDesktopPortal
+import com.zugaldia.stargate.sdk.screencast.ScreenCastPortal
 import com.zugaldia.stargate.sdk.settings.SettingsPortal
 import org.freedesktop.dbus.connections.impl.DBusConnection
 import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
@@ -44,6 +45,11 @@ class DesktopPortal(private val connection: DBusConnection) : AutoCloseable {
      * Access to the OpenURI portal for opening URIs in the user's preferred application.
      */
     val openUri: OpenUriPortal by lazy { OpenUriPortal(connection) }
+
+    /**
+     * Access to the ScreenCast portal for capturing screen content via PipeWire.
+     */
+    val screenCast: ScreenCastPortal by lazy { ScreenCastPortal(connection) }
 
     /**
      * Closes the underlying D-Bus connection.

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/PersistMode.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/PersistMode.kt
@@ -1,10 +1,10 @@
-package com.zugaldia.stargate.sdk.remotedesktop
+package com.zugaldia.stargate.sdk
 
 import org.freedesktop.dbus.types.UInt32
 
 /**
- * Represents how a remote desktop session should persist.
- * Added in version 2 of the RemoteDesktop interface.
+ * Represents how a portal session should persist.
+ * Used by RemoteDesktop and ScreenCast portals.
  */
 enum class PersistMode(val value: UInt32) {
     /**

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/remotedesktop/RemoteDesktopConstants.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/remotedesktop/RemoteDesktopConstants.kt
@@ -1,24 +1,6 @@
 package com.zugaldia.stargate.sdk.remotedesktop
 
 /**
- * Option key for device types bitmask.
- * Used in RemoteDesktop.SelectDevices.
- */
-const val OPTION_TYPES = "types"
-
-/**
- * Option key for restore token.
- * Used to restore a previous session.
- */
-const val OPTION_RESTORE_TOKEN = "restore_token"
-
-/**
- * Option key for persist mode.
- * Controls how long permissions persist.
- */
-const val OPTION_PERSIST_MODE = "persist_mode"
-
-/**
  * Result key for devices bitmask returned in Start response.
  */
 const val RESULT_DEVICES = "devices"
@@ -28,12 +10,6 @@ const val RESULT_DEVICES = "devices"
  * Since version 2.
  */
 const val RESULT_CLIPBOARD_ENABLED = "clipboard_enabled"
-
-/**
- * Result key for restore token returned in Start response.
- * Since version 2.
- */
-const val RESULT_RESTORE_TOKEN = "restore_token"
 
 /**
  * Option key for the finish flag in NotifyPointerAxis.

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/remotedesktop/RemoteDesktopPortal.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/remotedesktop/RemoteDesktopPortal.kt
@@ -1,8 +1,14 @@
 package com.zugaldia.stargate.sdk.remotedesktop
 
 import com.zugaldia.stargate.sdk.BUS_NAME
+import com.zugaldia.stargate.sdk.EMPTY_OPTIONS
 import com.zugaldia.stargate.sdk.OBJECT_PATH
 import com.zugaldia.stargate.sdk.OPTION_HANDLE_TOKEN
+import com.zugaldia.stargate.sdk.OPTION_PERSIST_MODE
+import com.zugaldia.stargate.sdk.OPTION_RESTORE_TOKEN
+import com.zugaldia.stargate.sdk.OPTION_TYPES
+import com.zugaldia.stargate.sdk.PersistMode
+import com.zugaldia.stargate.sdk.RESULT_RESTORE_TOKEN
 import com.zugaldia.stargate.sdk.generateToken
 import com.zugaldia.stargate.sdk.request.awaitPortalResponse
 import com.zugaldia.stargate.sdk.session.CreateSessionResponse
@@ -16,8 +22,6 @@ import org.freedesktop.dbus.connections.impl.DBusConnection
 import org.freedesktop.dbus.types.UInt32
 import org.freedesktop.dbus.types.Variant
 import org.freedesktop.portal.RemoteDesktop
-
-private val EMPTY_OPTIONS = emptyMap<String, Variant<*>>()
 
 /**
  * Wrapper around the org.freedesktop.portal.RemoteDesktop D-Bus interface.

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/CursorMode.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/CursorMode.kt
@@ -1,0 +1,44 @@
+package com.zugaldia.stargate.sdk.screencast
+
+import org.freedesktop.dbus.types.UInt32
+
+private const val HIDDEN_BITMASK = 1
+private const val EMBEDDED_BITMASK = 2
+private const val METADATA_BITMASK = 4
+
+/**
+ * Represents how the cursor should be rendered in the screencast stream.
+ * These are defined as a bitmask in the portal specification.
+ */
+enum class CursorMode(val value: Int) {
+    /**
+     * The cursor is not part of the stream.
+     */
+    HIDDEN(HIDDEN_BITMASK),
+
+    /**
+     * The cursor is embedded into the stream.
+     */
+    EMBEDDED(EMBEDDED_BITMASK),
+
+    /**
+     * The cursor is not part of the screencast stream, but sent as PipeWire stream metadata.
+     */
+    METADATA(METADATA_BITMASK);
+
+    companion object {
+        /**
+         * Parses a bitmask value into a set of cursor modes.
+         */
+        fun fromBitmask(bitmask: UInt32): Set<CursorMode> {
+            val mask = bitmask.toInt()
+            return entries.filter { (mask and it.value) != 0 }.toSet()
+        }
+
+        /**
+         * Converts a set of cursor modes into a bitmask value.
+         */
+        fun toBitmask(modes: Set<CursorMode>): UInt32 =
+            UInt32(modes.fold(0L) { acc, mode -> acc or mode.value.toLong() })
+    }
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/ScreenCastConstants.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/ScreenCastConstants.kt
@@ -1,0 +1,18 @@
+package com.zugaldia.stargate.sdk.screencast
+
+/**
+ * Option key for allowing multiple source selection.
+ * Used in ScreenCast.SelectSources.
+ */
+const val OPTION_MULTIPLE = "multiple"
+
+/**
+ * Option key for cursor mode.
+ * Used in ScreenCast.SelectSources.
+ */
+const val OPTION_CURSOR_MODE = "cursor_mode"
+
+/**
+ * Result key for streams array returned in Start response.
+ */
+const val RESULT_STREAMS = "streams"

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/ScreenCastPortal.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/ScreenCastPortal.kt
@@ -1,0 +1,227 @@
+package com.zugaldia.stargate.sdk.screencast
+
+import com.zugaldia.stargate.sdk.BUS_NAME
+import com.zugaldia.stargate.sdk.EMPTY_OPTIONS
+import com.zugaldia.stargate.sdk.OBJECT_PATH
+import com.zugaldia.stargate.sdk.OPTION_HANDLE_TOKEN
+import com.zugaldia.stargate.sdk.OPTION_PERSIST_MODE
+import com.zugaldia.stargate.sdk.OPTION_RESTORE_TOKEN
+import com.zugaldia.stargate.sdk.OPTION_TYPES
+import com.zugaldia.stargate.sdk.PersistMode
+import com.zugaldia.stargate.sdk.RESULT_RESTORE_TOKEN
+import com.zugaldia.stargate.sdk.generateToken
+import com.zugaldia.stargate.sdk.request.awaitPortalResponse
+import com.zugaldia.stargate.sdk.session.CreateSessionResponse
+import com.zugaldia.stargate.sdk.session.PortalSession
+import com.zugaldia.stargate.sdk.session.SessionClosedEvent
+import kotlinx.coroutines.flow.Flow
+import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.FileDescriptor
+import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.types.UInt32
+import org.freedesktop.dbus.types.Variant
+import org.freedesktop.portal.ScreenCast
+
+/**
+ * Wrapper around the org.freedesktop.portal.ScreenCast D-Bus interface.
+ * Provides convenient methods to capture screen content via PipeWire streams.
+ *
+ * This portal maintains an active session internally. After calling [startSession],
+ * the PipeWire remote can be opened with [openPipeWireRemote].
+ */
+class ScreenCastPortal(private val connection: DBusConnection) {
+
+    private val screenCast: ScreenCast =
+        connection.getRemoteObject(BUS_NAME, OBJECT_PATH, ScreenCast::class.java)
+
+    private val session = PortalSession(connection)
+
+    /**
+     * The currently active session handle, set automatically by [startSession].
+     */
+    val activeSession: DBusPath?
+        get() = session.active
+
+    /**
+     * Clears the active session.
+     */
+    fun clearSession() {
+        session.clear()
+    }
+
+    /**
+     * Returns a Flow that emits when the active session is closed.
+     *
+     * @return Flow of session closed events.
+     */
+    fun observeSessionClosed(): Flow<SessionClosedEvent> = session.observeClosed()
+
+    /**
+     * Returns the interface version.
+     */
+    val version: Int
+        get() = screenCast.getVersion().toInt()
+
+    /**
+     * Returns the available source types as a set of [SourceType] values.
+     */
+    val availableSourceTypes: Set<SourceType>
+        get() = SourceType.fromBitmask(screenCast.availableSourceTypes)
+
+    /**
+     * Returns the available cursor modes as a set of [CursorMode] values.
+     */
+    val availableCursorModes: Set<CursorMode>
+        get() = CursorMode.fromBitmask(screenCast.availableCursorModes)
+
+    /**
+     * Creates a new screencast session.
+     *
+     * @return Result containing [CreateSessionResponse] with the session handle.
+     */
+    suspend fun createSession(): Result<CreateSessionResponse> = session.createSession(
+        call = { options -> screenCast.CreateSession(options) }
+    )
+
+    /**
+     * Select sources to capture for the given session. This must be called before starting
+     * the session, and an application may only attempt to select sources once per session.
+     *
+     * Passing invalid input will cause the session to be closed.
+     *
+     * @param sessionHandle Object path for the session created via [createSession].
+     * @param types Set of source types to allow the user to select. Default is MONITOR.
+     * @param multiple Whether to allow selecting multiple sources.
+     * @param cursorMode How the cursor should appear in the stream.
+     * @param restoreToken Optional token to restore a previous session (version 4+).
+     * @param persistMode How this session should persist (version 4+).
+     * @return Result indicating success or failure.
+     */
+    suspend fun selectSources(
+        sessionHandle: DBusPath,
+        types: Set<SourceType>? = null,
+        multiple: Boolean? = null,
+        cursorMode: CursorMode? = null,
+        restoreToken: String? = null,
+        persistMode: PersistMode? = null
+    ): Result<Unit> {
+        val options = buildMap<String, Variant<*>> {
+            put(OPTION_HANDLE_TOKEN, Variant(generateToken()))
+            types?.let { put(OPTION_TYPES, Variant(SourceType.toBitmask(it))) }
+            multiple?.let { put(OPTION_MULTIPLE, Variant(it)) }
+            cursorMode?.let { put(OPTION_CURSOR_MODE, Variant(UInt32(cursorMode.value.toLong()))) }
+            restoreToken?.let { put(OPTION_RESTORE_TOKEN, Variant(it)) }
+            persistMode?.let { put(OPTION_PERSIST_MODE, Variant(it.value)) }
+        }
+
+        return awaitPortalResponse(
+            connection = connection,
+            methodName = "SelectSources",
+            call = { screenCast.SelectSources(sessionHandle, options) },
+            parseSuccess = { }
+        )
+    }
+
+    /**
+     * Start the screencast session. This will typically present a dialog for the user
+     * to confirm the selection configured via [selectSources].
+     *
+     * A screencast session may only be started after having selected sources, and
+     * an application can only attempt to start a session once.
+     *
+     * @param sessionHandle Object path for the session created via [createSession].
+     * @param parentWindow Identifier for the application window (see Window Identifiers).
+     *                     Use empty string if no parent window.
+     * @return Result containing [StartResponse] with the selected PipeWire streams.
+     */
+    suspend fun start(
+        sessionHandle: DBusPath,
+        parentWindow: String = ""
+    ): Result<StartResponse> {
+        val options = mapOf(OPTION_HANDLE_TOKEN to Variant(generateToken()))
+
+        return awaitPortalResponse(
+            connection = connection,
+            methodName = "Start",
+            call = { screenCast.Start(sessionHandle, parentWindow, options) },
+            parseSuccess = { results ->
+                StartResponse(
+                    streams = parseStreamsResult(results),
+                    restoreToken = results[RESULT_RESTORE_TOKEN]?.value as? String
+                )
+            }
+        )
+    }
+
+    /**
+     * Convenience function that performs the complete screencast session flow:
+     * creates a session, selects sources, and starts the session.
+     *
+     * @param types Set of source types to allow the user to select.
+     * @param multiple Whether to allow selecting multiple sources.
+     * @param cursorMode How the cursor should appear in the stream.
+     * @param restoreToken Optional token to restore a previous session (version 4+).
+     * @param persistMode How this session should persist (version 4+).
+     * @param parentWindow Identifier for the application window. Use empty string if no parent window.
+     * @return Result containing [StartResponse] with the selected PipeWire streams.
+     */
+    @Suppress("ReturnCount")
+    suspend fun startSession(
+        types: Set<SourceType>? = null,
+        multiple: Boolean? = null,
+        cursorMode: CursorMode? = null,
+        restoreToken: String? = null,
+        persistMode: PersistMode? = null,
+        parentWindow: String = ""
+    ): Result<StartResponse> {
+        // Step 1: Create the session
+        val sessionHandle = createSession().getOrElse { return Result.failure(it) }.sessionHandle
+        session.set(sessionHandle)
+
+        // Step 2: Select sources
+        selectSources(sessionHandle, types, multiple, cursorMode, restoreToken, persistMode).getOrElse {
+            clearSession()
+            return Result.failure(it)
+        }
+
+        // Step 3: Start the session
+        return start(sessionHandle, parentWindow).onFailure {
+            clearSession()
+        }
+    }
+
+    /**
+     * Opens a PipeWire remote for the given session, returning a file descriptor
+     * that can be passed to a PipeWire client to access the stream.
+     *
+     * Must be called after [start] succeeds.
+     *
+     * @param sessionHandle Object path for the session created via [createSession].
+     * @return Result containing a file descriptor for the PipeWire remote.
+     */
+    fun openPipeWireRemote(sessionHandle: DBusPath): Result<FileDescriptor> = runCatching {
+        screenCast.OpenPipeWireRemote(sessionHandle, EMPTY_OPTIONS)
+    }
+
+    /**
+     * Opens a PipeWire remote using the active session handle.
+     *
+     * Must be called after [startSession] succeeds.
+     *
+     * @return Result containing a file descriptor for the PipeWire remote.
+     */
+    fun openPipeWireRemote(): Result<FileDescriptor> = session.withSession { sessionHandle ->
+        screenCast.OpenPipeWireRemote(sessionHandle, EMPTY_OPTIONS)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseStreamsResult(results: Map<String, Variant<*>>): List<StreamInfo> {
+        val streamsRaw = results[RESULT_STREAMS]?.value as? List<*> ?: return emptyList()
+        return streamsRaw.mapNotNull { item ->
+            val struct = item as? Array<*> ?: return@mapNotNull null
+            val nodeId = struct.getOrNull(0) as? UInt32 ?: return@mapNotNull null
+            val props = struct.getOrNull(1) as? Map<String, Variant<*>> ?: emptyMap()
+            StreamInfo(nodeId = nodeId, properties = props)
+        }
+    }
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/SourceType.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/SourceType.kt
@@ -1,0 +1,33 @@
+package com.zugaldia.stargate.sdk.screencast
+
+import org.freedesktop.dbus.types.UInt32
+
+private const val MONITOR_BITMASK = 1
+private const val WINDOW_BITMASK = 2
+private const val VIRTUAL_BITMASK = 4
+
+/**
+ * Represents the available source types for screencasting.
+ * These are defined as a bitmask in the portal specification.
+ */
+enum class SourceType(val value: Int) {
+    MONITOR(MONITOR_BITMASK),
+    WINDOW(WINDOW_BITMASK),
+    VIRTUAL(VIRTUAL_BITMASK);
+
+    companion object {
+        /**
+         * Parses a bitmask value into a set of source types.
+         */
+        fun fromBitmask(bitmask: UInt32): Set<SourceType> {
+            val mask = bitmask.toInt()
+            return entries.filter { (mask and it.value) != 0 }.toSet()
+        }
+
+        /**
+         * Converts a set of source types into a bitmask value.
+         */
+        fun toBitmask(types: Set<SourceType>): UInt32 =
+            UInt32(types.fold(0L) { acc, type -> acc or type.value.toLong() })
+    }
+}

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/StartResponse.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/StartResponse.kt
@@ -1,0 +1,12 @@
+package com.zugaldia.stargate.sdk.screencast
+
+/**
+ * Response from ScreenCast.Start containing the selected streams.
+ *
+ * @property streams The list of PipeWire streams selected by the user.
+ * @property restoreToken Token to restore this session later (version 4+).
+ */
+data class StartResponse(
+    val streams: List<StreamInfo>,
+    val restoreToken: String?
+)

--- a/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/StreamInfo.kt
+++ b/sdk/src/main/kotlin/com/zugaldia/stargate/sdk/screencast/StreamInfo.kt
@@ -1,0 +1,15 @@
+package com.zugaldia.stargate.sdk.screencast
+
+import org.freedesktop.dbus.types.UInt32
+import org.freedesktop.dbus.types.Variant
+
+/**
+ * Represents a PipeWire stream returned by ScreenCast.Start.
+ *
+ * @property nodeId The PipeWire node identifier for this stream.
+ * @property properties Additional stream properties (e.g., position, size, source_type).
+ */
+data class StreamInfo(
+    val nodeId: UInt32,
+    val properties: Map<String, Variant<*>>
+)


### PR DESCRIPTION
## Summary

- Implement `ScreenCastPortal` wrapping `org.freedesktop.portal.ScreenCast` with session management, source selection (`SelectSources`), stream starting (`Start`), and PipeWire remote access (`OpenPipeWireRemote`)
- Add supporting types: `SourceType`, `CursorMode`, `StreamInfo`, `StartResponse`, and portal-specific constants
- Move `PersistMode` from `remotedesktop` to shared `sdk` package since both RemoteDesktop and ScreenCast portals use identical definitions
- Deduplicate shared constants (`OPTION_TYPES`, `OPTION_RESTORE_TOKEN`, `OPTION_PERSIST_MODE`, `RESULT_RESTORE_TOKEN`, `EMPTY_OPTIONS`) into `DesktopConstants.kt`
- Wire `ScreenCastPortal` into `DesktopPortal` entry point via lazy initialization
- Update README portal status table

## Test plan

- [ ] `./gradlew build` passes
- [ ] `./gradlew detekt` passes
- [ ] Verify RemoteDesktop portal still works (imports updated)
- [ ] Test ScreenCast session flow on a portal-capable desktop