### PR TITLE
Fix Dokka module name to produce clean URLs

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -73,7 +73,7 @@ tasks.flatpakGradleGenerator {
 }
 
 dokka {
-    moduleName.set("Stargate SDK")
+    moduleName.set("sdk")
     dokkaSourceSets.named("main") {
         sourceLink {
             localDirectory.set(file("src/main/kotlin"))


### PR DESCRIPTION
## Summary

- Changes `moduleName` in `sdk/build.gradle.kts` from `"Stargate SDK"` to `"sdk"`

Dokka 2.x converts the module name to a URL path segment using camelCase-to-kebab conversion. The previous name produced a malformed URL segment (`-stargate%20-s-d-k`) because the space became `%20` and each letter of the "SDK" acronym was treated as a separate word boundary. Using `"sdk"` results in a clean `-sdk` path segment, and avoids redundancy since the site root already contains `/stargate/`.